### PR TITLE
WebUIの認証をDigestからBasicに変更

### DIFF
--- a/lib/command/setting.rb
+++ b/lib/command/setting.rb
@@ -642,25 +642,18 @@ module Command
           invisible: true,
           tab: :global
         },
-        "server-digest-auth.enable" => {
-          type: :boolean, help: "WEBサーバでDigest認証を使用するかどうか",
+        "server-basic-auth.enable" => {
+          type: :boolean, help: "WEBサーバでBasic認証を使用するかどうか",
           invisible: true,
           tab: :global
         },
-        "server-digest-auth.user" => {
-          type: :string, help: "WEBサーバでDigest認証をするユーザ名",
+        "server-basic-auth.user" => {
+          type: :string, help: "WEBサーバでBasic認証をするユーザ名",
           invisible: true,
           tab: :global
         },
-        "server-digest-auth.password" => {
-          type: :string, help: "WEBサーバのDigest認証のパスワード。hashed-passwordも設定した場合はそちらが優先される",
-          invisible: true,
-          tab: :global
-        },
-        "server-digest-auth.hashed-password" => {
-          type: :string,
-          help: "WEBサーバのDigest認証のパスワードを、Realmを\"narou.rb\"としてハッシュにしたもの。下記のようなコマンドで生成できる\n" \
-                "$ ruby -r 'digest/md5' -e 'puts Digest::MD5.hexdigest \"\#{$*[0]}:narou.rb:\#{$*[1]}\"' user password",
+        "server-basic-auth.password" => {
+          type: :string, help: "WEBサーバのBasic認証のパスワード",
           invisible: true,
           tab: :global
         },

--- a/lib/web/appserver.rb
+++ b/lib/web/appserver.rb
@@ -167,19 +167,17 @@ class Narou::AppServer < Sinatra::Base
   end
 
   # サーバーの認証の設定
-  # とりあえずDigest認証のみ
+  # - Digest認証がRackの機能からオミットされたので、Basic認証に変更
   def setup_server_authentication
-    auth = Inventory.load("global_setting", :global).group("server-digest-auth")
+    auth = Inventory.load("global_setting", :global).group("server-basic-auth")
     user = auth.user
-    hashed = auth.hashed_password
-    passwd = hashed || auth.password
+    passwd = auth.password  # ハッシュは使わない
 
-    # enableかつユーザー名とパスワードが設定されている時のみ認証を有効にする
     return unless auth.enable && user && passwd
 
     self.class.class_exec do
-      use Rack::Auth::Digest::MD5, { realm: "narou.rb", opaque: "", passwords_hashed: hashed } do |username|
-        passwd if username == user
+      use Rack::Auth::Basic, "narou.rb" do |username, password|
+        username == user && password == passwd
       end
     end
   end

--- a/lib/web/settingmessages.rb
+++ b/lib/web/settingmessages.rb
@@ -21,9 +21,7 @@ module Narou
     "no-color" => "コンソールのカラー表示を無効にする\n※要サーバ再起動",
     "economy" => "容量節約に関する設定",
     "send.without-freeze" => "一括送信時に凍結された小説は対象外にする。（個別送信時は凍結済みでも送信可能）",
-    "server-digest-auth.enable" => "%%ORIG%%\n※digest-auth関連の設定を変更した場合サーバの再起動が必要",
-    "server-digest-auth.hashed-password" => "サーバのDigest認証のパスワードを、Realmを\"narou.rb\"としてハッシュにしたもの。\n" \
-                                            "https://tgws.plus/app/digest/ などで生成できる",
+    "server-basic-auth.enable" => "%%ORIG%%\n※basic-auth関連の設定を変更した場合サーバの再起動が必要",
     "concurrency" => "%%ORIG%% ※要サーバ再起動",
     "logging" => "%%ORIG%%\n※要サーバ再起動",
     "logging.format-filename" => "%%ORIG%%\n※要サーバ再起動",


### PR DESCRIPTION
rackでのダイジェスト認証のサポートが廃止されているため、Basic認証に変更