### PR TITLE
小説変換処理の高速化

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,9 @@
 PATH
   remote: .
   specs:
-    narou (3.9.1.20251024d)
+    narou (3.9.1)
       activesupport (~> 8.0, >= 8.1.0)
+      bootsnap (~> 1.18, >= 1.18.6)
       csv (~> 3.3)
       diff-lcs (~> 1.6, >= 1.6.2)
       erubi (~> 1.13.1)
@@ -47,6 +48,8 @@ GEM
     base64 (0.3.0)
     bigdecimal (3.3.1)
     bigdecimal (3.3.1-java)
+    bootsnap (1.18.6)
+      msgpack (~> 1.2)
     byebug (12.0.0)
     coderay (1.1.3)
     concurrent-ruby (1.3.5)
@@ -81,6 +84,8 @@ GEM
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
     minitest (5.14.4)
+    msgpack (1.8.0)
+    msgpack (1.8.0-java)
     multi_json (1.15.0)
     mustermann (3.0.4)
       ruby2_keywords (~> 0.0.1)

--- a/lib/converterbase.rb
+++ b/lib/converterbase.rb
@@ -1368,7 +1368,7 @@ class ConverterBase
       @write_fp.write(data)
     else
       @read_fp.each_with_index do |line, i|
-        progressbar.output(i) if progressbar
+        progressbar.output(i) if progressbar && (i % 50).zero?  # 50行ごとに制限
         @request_skip_output_line = false
         zenkaku_rstrip(line)
         if @request_insert_blank_next_line

--- a/lib/converterbase.rb
+++ b/lib/converterbase.rb
@@ -45,6 +45,7 @@ class ConverterBase
     @subtitles = nil
     @data_type = "text"
     @current_index = 0
+    @device = Narou.get_device
     reset_member_values
   end
 
@@ -65,7 +66,6 @@ class ConverterBase
     @num_and_comma_list = {}
     @force_indent_special_chapter_list = {}
     @in_author_comment_block = nil
-    @device = Narou.get_device
   end
 
   def outputs(data = "", force = false)
@@ -1330,6 +1330,17 @@ class ConverterBase
     data = replace_by_replace_txt(io.read)
     data = insert_separator_for_selection(data)
     return data
+  end
+
+  # 複数のテキストをまとめて変換する
+  # pairs: { key1 => [text, text_type], key2 => [text, text_type], ... }
+  # 戻り値: { key1 => converted_text1, key2 => converted_text2, ... }
+  def convert_multi(pairs)
+    results = {}
+    pairs.each do |key, (text, text_type)|
+      results[key] = convert(text, text_type)
+    end
+    results
   end
 
   #

--- a/lib/novelconverter.rb
+++ b/lib/novelconverter.rb
@@ -827,7 +827,7 @@ class NovelConverter
   # subtitle info から変換処理をする
   #
   def subtitles_to_sections(subtitles, html)
-    # 章データキャッシュ
+    # 章データをキャッシュ
     @__section_cache ||= {}
 
     sections = []
@@ -839,37 +839,61 @@ class NovelConverter
       trigger(:"convert_main.loop", i)
       @converter.current_index = i
 
-      # Yamlロードをキャッシュ
+      # YAMLロードをキャッシュ
       key = subinfo["index"]
-      section = @__section_cache[key]
-      unless section
-        # load_novel_section はハッシュを返す
-        section = load_novel_section(subinfo, section_save_dir)
-        @__section_cache[key] = section
+      original_section = @__section_cache[key]
+      unless original_section
+        original_section = load_novel_section(subinfo, section_save_dir)
+        @__section_cache[key] = original_section
       end
 
-      # dupしてから編集する事でキャッシュ汚染を防ぐ
-      section = section.dup
-      section["element"] = section["element"].dup
+      # キャッシュを壊さないようディープ寄りにdup
+      # （chapter/subtitle/elementなど後で書き換えるので）
+      section = original_section.dup
+      section["element"] = original_section["element"].dup
 
-      # Converter呼び出しを一箇所に集約
-      if section["chapter"] && !section["chapter"].empty?
-        section["chapter"] = @converter.convert(section["chapter"], "chapter")
-      end
-
-      @inspector.subtitle = section["subtitle"]
-      section["subtitle"] = @converter.convert(section["subtitle"], "subtitle")
-
+      # data_type 判定
       element = section["element"]
       data_type = element.delete("data_type") || "text"
       @converter.data_type = data_type
 
+      # HTML→青空変換が必要なやつを先にプレーンテキスト化
+      preprocessed_element_texts = {}
       element.each do |text_type, elm_text|
         if data_type != "text"
           html.string = elm_text
           elm_text = html.to_aozora(pre_html: data_type == "pre_html")
         end
-        element[text_type] = @converter.convert(elm_text, text_type)
+        preprocessed_element_texts[text_type] = elm_text
+      end
+
+      # まとめてコンバータに渡すためのバッチ入力を作る
+      batch_inputs = {}
+
+      # chapter
+      if section["chapter"] && !section["chapter"].empty?
+        batch_inputs[:chapter] = [section["chapter"], "chapter"]
+      end
+
+      # subtitle
+      @inspector.subtitle = section["subtitle"]
+      batch_inputs[:subtitle] = [section["subtitle"], "subtitle"]
+
+      # element 各種
+      preprocessed_element_texts.each do |text_type, body_text|
+        batch_inputs[[:element, text_type]] = [body_text, text_type]
+      end
+
+      # 一括変換
+      converted = @converter.convert_multi(batch_inputs)
+      if batch_inputs[:chapter]
+        section["chapter"] = converted[:chapter]
+      end
+
+      section["subtitle"] = converted[:subtitle]
+
+      element.keys.each do |text_type|
+        section["element"][text_type] = converted[[:element, text_type]]
       end
 
       sections << section
@@ -880,6 +904,7 @@ class NovelConverter
   ensure
     trigger(:"convert_main.finish")
   end
+
 
   #
   # テキストデータ先頭二行からタイトルと作者名を取得

--- a/lib/novelconverter.rb
+++ b/lib/novelconverter.rb
@@ -259,97 +259,64 @@ class NovelConverter
   #
   def self.add_dc_subject_to_epub(epub_path, subjects, stream_io: $stdout2)
     return :success if subjects.nil? || subjects.empty?
-
-    # 必要なgemが利用できない場合は警告を出して処理をスキップ
     if defined?(ZIP_UNAVAILABLE)
       stream_io.error "dc:subject埋め込み機能を使用するにはrubyzip gemが必要です"
       return :error
     end
 
-    if defined?(REXML_UNAVAILABLE)
-      stream_io.error "dc:subject埋め込み機能を使用するにはrexml gemが必要です"
-      return :error
-    end
-
-    temp_dir = nil
+    entries = {}
     begin
-      # 一時ディレクトリ作成
-      temp_dir = Dir.mktmpdir
-
-      # EPUBファイルを展開
+      # EPUBをメモリ上に展開
       Zip::File.open(epub_path) do |zip_file|
         zip_file.each do |entry|
-          entry_path = File.join(temp_dir, entry.name)
-          FileUtils.mkdir_p(File.dirname(entry_path))
-          entry.extract(entry_path)
+          entries[entry.name] = entry.get_input_stream.read
         end
       end
 
-      # standard.opfファイルを探す
-      opf_path = Dir.glob(File.join(temp_dir, "**", "standard.opf")).first
-      unless opf_path
+      # standard.opf 書き換え
+      opf_name, opf_body = entries.find { |name, _| name.end_with?("standard.opf") }
+      unless opf_name
         stream_io.error "standard.opfファイルが見つかりませんでした"
         return :error
       end
 
-      # 文字列置換でdc:subjectを追加する方式に変更
-      # （REXMLの整形では元のフォーマットが崩れるため）
-      content = File.read(opf_path)
-
-      # 既存のdc:subjectを削除
+      content = opf_body.dup
       content.gsub!(/<dc:subject>.*?<\/dc:subject>\s*\n?\s*/m, "")
-
-      # 新しいdc:subjectを生成（XMLエスケープも行う）
-      dc_subject_lines = subjects.map do |subject|
-        next if subject.strip.empty?
-        escaped_subject = subject.strip.gsub("&", "&amp;").gsub("<", "&lt;").gsub(">", "&gt;").gsub("\"", "&quot;").gsub("'", "&apos;")
-        "    <dc:subject>#{escaped_subject}</dc:subject>"
-      end.compact
-
+      dc_subject_lines = subjects.map(&:strip).reject(&:empty?).map { |s|
+        esc = s.gsub("&","&amp;").gsub("<","&lt;").gsub(">","&gt;").gsub("\"","&quot;").gsub("'","&apos;")
+        "    <dc:subject>#{esc}</dc:subject>"
+      }
       if dc_subject_lines.any?
-        # </metadata>の直前にdc:subjectを挿入
         dc_subjects_xml = dc_subject_lines.join("\n") + "\n"
         content.sub!(/(\s*)<\/metadata>/, "\n#{dc_subjects_xml}\\1</metadata>")
       end
+      entries[opf_name] = content
 
-      # XMLを書き戻し
-      File.write(opf_path, content)
-
-      # EPUBファイルを再作成（OutputStreamを使用しmimetypeを無圧縮・先頭に配置）
+      # 再Zip化 (mimetypeは無圧縮で先頭)
       File.delete(epub_path)
-
       Zip::OutputStream.open(epub_path) do |zos|
-        # mimetypeファイルを最初に無圧縮で追加
-        mimetype_path = File.join(temp_dir, "mimetype")
-        unless File.exist?(mimetype_path)
+        # mimetype必須
+        if !entries["mimetype"]
           stream_io.error "mimetypeファイルが見つかりません"
           return :error
         end
 
         # 第1引数に名前、第4引数にZip::Entry::STORED を渡す
-        zos.put_next_entry('mimetype', nil, nil, Zip::Entry::STORED)
+        zos.put_next_entry("mimetype", nil, nil, Zip::Entry::STORED)
+        zos.write entries["mimetype"]
 
-        zos.write File.read(mimetype_path, mode: "rb")
-
-        # 他のファイルを追加（mimetypeを除く）
-        Dir.glob(File.join(temp_dir, "**", "*"), File::FNM_DOTMATCH).sort.each do |file_path|
-          next if File.directory?(file_path)
-          relative_path = file_path.sub(temp_dir + "/", "")
-          next if relative_path == "mimetype"  # mimetypeは既に追加済み
-          zos.put_next_entry(relative_path)
-          zos.write File.read(file_path, mode: "rb")
+        entries.each do |name, body|
+          next if name == "mimetype"
+          zos.put_next_entry(name)
+          zos.write body
         end
       end
 
       stream_io.puts "dc:subjectを追加しました: #{subjects.join(', ')}"
       :success
-
     rescue => e
       stream_io.error "dc:subject追加中にエラーが発生しました: #{e.message}"
       :error
-    ensure
-      # 一時ディレクトリを削除
-      FileUtils.rm_rf(temp_dir) if temp_dir
     end
   end
 

--- a/lib/novelconverter.rb
+++ b/lib/novelconverter.rb
@@ -575,9 +575,12 @@ class NovelConverter
     on(:"convert_main.init") do |subtitles|
       progressbar = ProgressBar.new(subtitles.size, io: stream_io)
     end
+
     on(:"convert_main.loop") do |i|
-      progressbar.output(i) if progressbar
+      # 毎回ではな10件ごとに絞る
+      progressbar.output(i) if progressbar && (i % 10).zero?
     end
+
     on(:"convert_main.finish") do
       progressbar.clear if progressbar
     end
@@ -611,13 +614,25 @@ class NovelConverter
     cover_chuki = create_cover_chuki
     device = Narou.get_device
     setting = @setting
-    toc["title"] = setting.novel_title unless setting.novel_title.empty?
+
+    toc["title"]  = setting.novel_title  unless setting.novel_title.empty?
     toc["author"] = setting.novel_author unless setting.novel_author.empty?
+
     processing_title = toc["title"]
     processing_title += "_#{index}" if index
     processed_title = decorate_title(processing_title)
     template_name = (device && device.ibunko? ? NOVEL_TEXT_TEMPLATE_NAME_FOR_IBUNKO : NOVEL_TEXT_TEMPLATE_NAME)
-    Template.get(template_name, binding, 1.1)
+
+    # テンプレートをキャッシュする
+    # コンパイル済みERB（またはProc）をキャッシュして binding だけ都度差し込む
+    @__template_cache ||= {}
+    compiled = @__template_cache[template_name]
+    unless compiled
+      compiled = Template.compile(template_name, 1.1)
+      @__template_cache[template_name] = compiled
+    end
+
+    Template.render(compiled, binding)
   end
 
   #
@@ -845,6 +860,9 @@ class NovelConverter
   # subtitle info から変換処理をする
   #
   def subtitles_to_sections(subtitles, html)
+    # 章データキャッシュ
+    @__section_cache ||= {}
+
     sections = []
     section_save_dir = Downloader.get_novel_section_save_dir(@setting.archive_path)
 
@@ -853,16 +871,32 @@ class NovelConverter
     subtitles.each_with_index do |subinfo, i|
       trigger(:"convert_main.loop", i)
       @converter.current_index = i
-      section = load_novel_section(subinfo, section_save_dir)
-      if section["chapter"].length > 0
+
+      # Yamlロードをキャッシュ
+      key = subinfo["index"]
+      section = @__section_cache[key]
+      unless section
+        # load_novel_section はハッシュを返す
+        section = load_novel_section(subinfo, section_save_dir)
+        @__section_cache[key] = section
+      end
+
+      # dupしてから編集する事でキャッシュ汚染を防ぐ
+      section = section.dup
+      section["element"] = section["element"].dup
+
+      # Converter呼び出しを一箇所に集約
+      if section["chapter"] && !section["chapter"].empty?
         section["chapter"] = @converter.convert(section["chapter"], "chapter")
       end
 
       @inspector.subtitle = section["subtitle"]
       section["subtitle"] = @converter.convert(section["subtitle"], "subtitle")
+
       element = section["element"]
       data_type = element.delete("data_type") || "text"
       @converter.data_type = data_type
+
       element.each do |text_type, elm_text|
         if data_type != "text"
           html.string = elm_text
@@ -870,8 +904,10 @@ class NovelConverter
         end
         element[text_type] = @converter.convert(elm_text, text_type)
       end
+
       sections << section
     end
+
     @use_dakuten_font = @converter.use_dakuten_font
     sections
   ensure

--- a/lib/template.rb
+++ b/lib/template.rb
@@ -13,6 +13,57 @@ class Template
 
   class LoadError < StandardError; end
 
+  # コンパイル済みテンプレートをキャッシュする
+  # { "novel.txt" => { erb: <ERB>, binary_version: 1.1, src_filename: "novel.txt" } }
+  # キャッシュする関係でスレッドセーフにはなっていないので、並列での変換処理を行う場合は対応が必要
+  @__compiled_cache = {}
+
+    #
+  # テンプレートを元にデータを作成
+  #
+  # テンプレートファイルの検索順位
+  # 1. root_dir/template
+  # 2. script_dir/template
+  #
+  def self.compile(src_filename, binary_version)
+    # すでにキャッシュ済みならそのまま返す
+    cached = @__compiled_cache[src_filename]
+    return cached if cached
+
+    # ファイル探索（getと同じロジック）
+    [Narou.root_dir, Narou.script_dir].each do |dir|
+      path = dir.join(TEMPLATE_DIR, src_filename + ".erb")
+      next unless path.exist?
+
+      src = Helper::CacheLoader.load(path)
+      erb = ERB.new(src, trim_mode: "-")
+
+      compiled = {
+        erb: erb,
+        binary_version: binary_version,
+        src_filename: src_filename
+      }
+
+      @__compiled_cache[src_filename] = compiled
+      return compiled
+    end
+
+    raise LoadError, "テンプレートファイルが見つかりません。(#{src_filename}.erb)"
+  end
+
+  def self.render(compiled, _binding)
+    # compiled は compile が返した Hash
+    @@binary_version = compiled[:binary_version]
+    @@src_filename   = compiled[:src_filename]
+
+    # target_binary_version から参照される @@src_version は
+    # テンプレート内で <%= Template.target_binary_version 1.1 %> みたいに呼ばれる想定
+    # なので、ここでは設定しない。テンプレの中から呼ばれた時点で
+    # @@src_version が更新され、invalid_templace_version? が機能する
+
+    compiled[:erb].result(_binding)
+  end
+
   #
   # テンプレートを元にファイルを作成
   #
@@ -36,24 +87,10 @@ class Template
     end
   end
 
-  #
-  # テンプレートを元にデータを作成
-  #
-  # テンプレートファイルの検索順位
-  # 1. root_dir/template
-  # 2. script_dir/template
-  #
+  # 既存コード向けのwrap関数
   def self.get(src_filename, _binding, binary_version)
-    @@binary_version = binary_version
-    @@src_filename = src_filename
-    [Narou.root_dir, Narou.script_dir].each do |dir|
-      path = dir.join(TEMPLATE_DIR, src_filename + ".erb")
-      next unless path.exist?
-      src = Helper::CacheLoader.load(path)
-      result = ERB.new(src, trim_mode: "-").result(_binding)
-      return result
-    end
-    raise LoadError, "テンプレートファイルが見つかりません。(#{src_filename}.erb)"
+    compiled = compile(src_filename, binary_version)
+    render(compiled, _binding)
   end
 
   def self.invalid_templace_version?

--- a/narou.gemspec
+++ b/narou.gemspec
@@ -70,6 +70,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'csv', '~> 3.3'
   gem.add_runtime_dependency 'rexml', '~> 3.4'
   gem.add_runtime_dependency 'sanitize', '~> 7.0.0'
+  gem.add_runtime_dependency 'bootsnap', '~> 1.18', '>= 1.18.6'
 
   gem.add_development_dependency 'rspec', '~> 3.13'
   gem.add_development_dependency 'rspec-retry', '~> 0.6'

--- a/narou.rb
+++ b/narou.rb
@@ -7,6 +7,17 @@
 # Copyright 2013 whiteleaf. All rights reserved.
 #
 
+require 'bootsnap'
+Bootsnap.setup(
+  cache_dir:            'tmp/cache',          # Path to your cache
+  ignore_directories:   [],                   # Directory names to skip.
+  development_mode:     false,                # Current working environment, e.g. RACK_ENV, RAILS_ENV, etc
+  load_path_cache:      true,                 # Optimize the LOAD_PATH with a cache
+  compile_cache_iseq:   true,                 # Compile Ruby code into ISeq cache, breaks coverage reporting.
+  compile_cache_yaml:   true,                 # Compile YAML into a cache
+  readonly:             true,                 # Use the caches but don't update them on miss or stale entries.
+)
+
 require_relative "lib/extension"
 require_relative "lib/extensions/monkey_patches"
 require_relative "lib/backtracer"


### PR DESCRIPTION
### 話数の多い（1000話オーバーなど）小説の変換処理を高速化
- 目次取得後の比較処理
- テキストからZipへの変換処理
- AozoraEpub3で変換する際のテキスト処理
### 全体的な高速化
- bootsnapの導入（コンパイルキャッシュ、PATHキャッシュなど）