### PR TITLE
Update R1.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,7 @@ GEM
     erubi (1.13.1)
     ffi (1.17.2)
     ffi (1.17.2-java)
+    ffi (1.17.2-x64-mingw-ucrt)
     haml (5.2.2)
       temple (>= 0.8.0)
       tilt
@@ -106,6 +107,8 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     nokogiri (1.18.10-java)
+      racc (~> 1.4)
+    nokogiri (1.18.10-x64-mingw-ucrt)
       racc (~> 1.4)
     open_uri_redirections (0.2.1)
     pony (1.13.1)
@@ -206,6 +209,7 @@ GEM
 PLATFORMS
   java
   ruby
+  x64-mingw-ucrt
 
 DEPENDENCIES
   awesome_print (~> 1.9)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    narou (3.9.1.mod.R1)
+    narou (3.9.1.mod.R1.1)
       activesupport (~> 8.0, >= 8.1.0)
       bootsnap (~> 1.18, >= 1.18.6)
       csv (~> 3.3)

--- a/lib/command/browser.rb
+++ b/lib/command/browser.rb
@@ -45,7 +45,13 @@ module Command
         if @options["vote"]
           # TODO: 最新話の場所をAPIで取得する
           data_dir = Downloader.get_novel_data_dir_by_target(data["id"])
-          latest_index = YAML.unsafe_load_file(File.join(data_dir, Downloader::TOC_FILE_NAME))["subtitles"].last["index"]
+          toc_path = File.join(data_dir, Downloader::TOC_FILE_NAME)
+          begin
+            latest_index = YAML.unsafe_load_file(toc_path)["subtitles"].last["index"]
+          rescue SystemCallError
+            # bootsnap on Windows can raise Errno::E01 errors, fallback to standard YAML
+            latest_index = YAML.unsafe_load(File.read(toc_path))["subtitles"].last["index"]
+          end
           open_url = "#{toc_url + latest_index}/#my_novelpoint"
         else
           open_url = toc_url

--- a/lib/command/diff.rb
+++ b/lib/command/diff.rb
@@ -212,8 +212,20 @@ module Command
       cache_sections = []
       cache_section_list.each do |path|
         match_latest_path = File.join(novel_dir, File.basename(path))
-        latest_novel_sections << YAML.unsafe_load_file(match_latest_path) if File.exist?(match_latest_path)
-        cache_sections << YAML.unsafe_load_file(path)
+        if File.exist?(match_latest_path)
+          begin
+            latest_novel_sections << YAML.unsafe_load_file(match_latest_path)
+          rescue SystemCallError
+            # bootsnap on Windows can raise Errno::E01 errors, fallback to standard YAML
+            latest_novel_sections << YAML.unsafe_load(File.read(match_latest_path))
+          end
+        end
+        begin
+          cache_sections << YAML.unsafe_load_file(path)
+        rescue SystemCallError
+          # bootsnap on Windows can raise Errno::E01 errors, fallback to standard YAML
+          cache_sections << YAML.unsafe_load(File.read(path))
+        end
       end
 
       novel_info = Database.instance[id]

--- a/lib/downloader.rb
+++ b/lib/downloader.rb
@@ -160,7 +160,11 @@ class Downloader
   # toc 読込
   #
   def self.get_toc_data(archive_path)
-    YAML.unsafe_load_file(File.join(archive_path, TOC_FILE_NAME))
+    path = File.join(archive_path, TOC_FILE_NAME)
+    YAML.unsafe_load_file(path)
+  rescue SystemCallError
+    # bootsnap on Windows can raise Errno::E01 errors, fallback to standard YAML
+    YAML.unsafe_load(File.read(path))
   end
 
   def self.get_toc_by_target(target)
@@ -1110,7 +1114,12 @@ class Downloader
   def different_section?(old_relative_path, new_subtitle_info)
     path = get_novel_data_dir.join(old_relative_path)
     return true unless path.exist?
-    YAML.unsafe_load_file(path)["element"] != new_subtitle_info["element"]
+    begin
+      YAML.unsafe_load_file(path)["element"] != new_subtitle_info["element"]
+    rescue SystemCallError
+      # bootsnap on Windows can raise Errno::E01 errors, fallback to standard YAML
+      YAML.unsafe_load(File.read(path))["element"] != new_subtitle_info["element"]
+    end
   end
 
   #
@@ -1361,6 +1370,11 @@ class Downloader
     YAML.unsafe_load_file(get_novel_data_dir.join(filename))
   rescue Errno::ENOENT
     nil
+  rescue SystemCallError => e
+    # bootsnap on Windows can raise Errno::E01 errors, fallback to standard YAML
+    path = get_novel_data_dir.join(filename)
+    return nil unless File.exist?(path)
+    YAML.unsafe_load(File.read(path))
   end
 
   #

--- a/lib/inventory.rb
+++ b/lib/inventory.rb
@@ -64,7 +64,12 @@ module Inventory
           error "#{@inventory_file_path} が壊れてるっぽい"
           raise
         end
-        YAML.unsafe_load_file(@inventory_file_path)
+        begin
+          YAML.unsafe_load_file(@inventory_file_path)
+        rescue SystemCallError
+          # bootsnap on Windows can raise Errno::E01 errors, fallback to standard YAML
+          YAML.unsafe_load(File.read(@inventory_file_path))
+        end
       end
     })
   end

--- a/lib/mailer.rb
+++ b/lib/mailer.rb
@@ -23,7 +23,12 @@ class Mailer
     this.clear
     setting_file_path = File.join(Narou.root_dir, SETTING_FILE)
     if File.exist?(setting_file_path)
-      options = YAML.unsafe_load_file(setting_file_path)
+      begin
+        options = YAML.unsafe_load_file(setting_file_path)
+      rescue SystemCallError
+        # bootsnap on Windows can raise Errno::E01 errors, fallback to standard YAML
+        options = YAML.unsafe_load(File.read(setting_file_path))
+      end
       unless options.delete(:complete)
         raise SettingUncompleteError, "設定ファイルの書き換えが終了していないようです。\n" +
                                       "設定ファイルは #{setting_file_path} にあります"

--- a/lib/novelconverter.rb
+++ b/lib/novelconverter.rb
@@ -565,7 +565,13 @@ class NovelConverter
   def load_novel_section(subtitle_info, section_save_dir)
     file_subtitle = subtitle_info["file_subtitle"] || subtitle_info["subtitle"]   # 互換性維持のため
     path = section_save_dir.join("#{subtitle_info["index"]} #{file_subtitle}.yaml")
-    YAML.unsafe_load_file(path)
+    begin
+      YAML.unsafe_load_file(path)
+    rescue SystemCallError => e
+      # bootsnap on Windows can raise Errno::E01 errors, fallback to standard YAML
+      raise if e.is_a?(Errno::ENOENT)
+      YAML.unsafe_load(File.read(path))
+    end
   rescue Errno::ENOENT => e
     stream_io.puts
     stream_io.error(<<~MSG.termcolor)

--- a/lib/sitesetting.rb
+++ b/lib/sitesetting.rb
@@ -73,7 +73,12 @@ class SiteSetting
 
   def initialize(path)
     @match_values = {}
-    @yaml = YAML.unsafe_load_file(path)
+    begin
+      @yaml = YAML.unsafe_load_file(path)
+    rescue SystemCallError
+      # bootsnap on Windows can raise Errno::E01 errors, fallback to standard YAML
+      @yaml = YAML.unsafe_load(File.read(path))
+    end
     @path = path
   end
 

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -5,5 +5,5 @@
 #
 
 module Narou
-  VERSION = "3.9.1.mod.R1"
+  VERSION = "3.9.1.mod.R1.1"
 end

--- a/lib/web/appserver.rb
+++ b/lib/web/appserver.rb
@@ -432,7 +432,13 @@ class Narou::AppServer < Sinatra::Base
     postscripts_count = 0
     toc["subtitles"].each do |sub|
       begin
-        element = YAML.unsafe_load_file(downloader.section_file_path(sub))["element"]
+        section_path = downloader.section_file_path(sub)
+        begin
+          element = YAML.unsafe_load_file(section_path)["element"]
+        rescue SystemCallError
+          # bootsnap on Windows can raise Errno::E01 errors, fallback to standard YAML
+          element = YAML.unsafe_load(File.read(section_path))["element"]
+        end
         data_type = element["data_type"] || "text"
         introduction = element["introduction"] || ""
         postscript = element["postscript"] || ""

--- a/lib/web/public/resources/css/default-style.css
+++ b/lib/web/public/resources/css/default-style.css
@@ -54,6 +54,27 @@
   user-select: none;
 }
 
+/* DataTables wrapper の背景色設定 */
+.dataTables_wrapper {
+  background-color: transparent;
+}
+
+#novel-list {
+  background-color: #fffcef !important;
+  /* DataTables 2.x のCSS変数を上書きして選択色を黄色系に */
+  --dt-row-selected: 241, 230, 178;  /* RGB値で指定 */
+  --dt-row-selected-text: 51, 51, 51;
+}
+
+#novel-list tbody tr {
+  background-color: inherit;
+}
+
+/* 選択行のスタイルを強制 */
+#novel-list tbody tr.selected > * {
+  box-shadow: inset 0 0 0 9999px rgba(255, 212, 0, 0.3) !important;
+}
+
 /* より包括的な選択防止 */
 body, * {
   -webkit-user-select: none;

--- a/lib/web/public/resources/js/narou.ui.js
+++ b/lib/web/public/resources/js/narou.ui.js
@@ -276,6 +276,7 @@ $(function() {
     dom: (touchable_device ? 'lprtpi' : 'Rlprtpi'),
     stateSave: true,
     stateDuration: 0,   // tableの状態保存を永続化
+    stripeClasses: ['odd', 'even'],  // DataTables 2.x互換: odd/evenクラスを明示的に指定
     stateLoadCallback: function(settings, callback) {
       try {
         var storageKey = 'DataTables_' + settings.sInstance + '_' + location.pathname;

--- a/lib/web/public/resources/js/narou.ui.js
+++ b/lib/web/public/resources/js/narou.ui.js
@@ -225,6 +225,88 @@ $(function() {
   window.action = action;
   var isInitialLoad = true;  // 初回ロードフラグ
 
+  /*
+   * ショートカット設定
+   * http://www.openjs.com/scripts/events/keyboard_shortcuts/index.php
+   */
+  var initialize_shortcut = function() {
+    var options = {
+      disable_in_input: true,
+    };
+    var add = function() {
+      var keys = [];
+      var callback = null;
+      for (var i = 0; i < arguments.length; i++) {
+        var value = arguments[i];
+        switch (typeof value) {
+        case "string":
+          keys.push(value);
+          break;
+        case "function":
+          callback = value;
+          break;
+        default:
+          $.error("invalid arguments: unknow type");
+          break;
+        }
+      }
+      if (!callback) $.error("shortcut error: need callback");
+      for (var i = 0; i < keys.length; i++) {
+        shortcut.add(keys[i], callback, options);
+      }
+    };
+
+    var click = function(id) {
+      return function() {
+        $(id).trigger("click");
+      };
+    };
+
+    add("Ctrl+A", "Meta+A", function(e) { 
+      console.log("[SHORTCUT] Ctrl+A pressed, action object:", window.action);
+      e.preventDefault(); // ブラウザのデフォルト動作（テキスト全選択）を防ぐ
+      if (window.action && window.action.selectView) {
+        console.log("[SHORTCUT] Calling action.selectView()");
+        window.action.selectView(); 
+      } else {
+        console.error("[SHORTCUT] action.selectView is not available!");
+      }
+    });
+    add("Shift+A", function(e) { 
+      console.log("[SHORTCUT] Shift+A pressed, action object:", window.action);
+      e.preventDefault(); // デフォルト動作を防ぐ
+      if (window.action && window.action.selectAll) {
+        console.log("[SHORTCUT] Calling action.selectAll()");
+        window.action.selectAll(); 
+      } else {
+        console.error("[SHORTCUT] action.selectAll is not available!");
+      }
+    });
+    add("Ctrl+Shift+A", "Meta+Shift+A", function() { window.action.selectClear(); });
+    add("ESC", function() {
+      if ($("#rect-select-menu").is(":visible")) {
+        close_rect_select_menu_handler();
+      }
+      if (!window.context_menu.closed) {
+        window.context_menu.close();
+      }
+      else {
+        window.action.selectClear();
+      }
+    });
+    add("S", click("#action-select-mode-single"));
+    add("R", click("#action-select-mode-rect"));
+    add("H", click("#action-select-mode-hybrid"));
+    add("W", click("#action-view-novel-list-wide"));
+    add("F", click("#action-view-frozen"));
+    add("Shift+F", click("#action-view-nonfrozen"));
+    add("T", click("#action-tag-edit"));
+    add("F5", function() { 
+      console.log("F5キーによる手動強制テーブルリロード");
+      Narou.tableReload(true); 
+    });
+  };
+
   function initializeDataTable(serverSortState) {
     var initialOrder = serverSortState ? [[serverSortState.column, serverSortState.dir]] : [[ 2, "desc" ]];
     
@@ -703,6 +785,11 @@ $(function() {
 
       datatables_init_completed = true;
       
+      // キーボードショートカットを初期化（actionが利用可能になった後）
+      if (!touchable_device) {
+        initialize_shortcut();
+      }
+      
       // 他のコンポーネントを初期化
       initializeComponents();
     },
@@ -866,125 +953,18 @@ $(function() {
       }, 350);
     });
 
-    // Shiftクリックによる意図しないテキスト選択を徹底的に防ぐ
+    // Shiftクリックによる意図しないテキスト選択を防ぐ（改訂版）
     
-    // ユーティリティ関数：許可する要素かチェック
-    function isAllowedElement(target) {
-      // 入力フィールドは許可
-      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.contentEditable === 'true') {
-        return true;
-      }
-      
-      // タグ要素は許可
-      var tagElement = $(target).closest('.tag[data-tag]:not(.tag-reset)')[0];
-      if (tagElement) {
-        return true;
-      }
-      
-      return false;
-    }
-    
-    // 選択を強制的にクリアする関数
-    function clearSelection() {
-      try {
-        if (window.getSelection) {
-          var selection = window.getSelection();
-          if (selection.rangeCount > 0) {
-            selection.removeAllRanges();
-          }
-        } else if (document.selection) {
-          document.selection.empty();
-        }
-      } catch (e) {
-        // エラーは無視
-      }
-    }
-    
-    // 1. 選択開始イベントを防ぐ
-    document.addEventListener('selectstart', function(e) {
-      if (e.shiftKey && !isAllowedElement(e.target)) {
-        console.log('Preventing selectstart on shift+click for:', e.target);
-        e.preventDefault();
-        e.stopPropagation();
-        e.stopImmediatePropagation();
-        clearSelection();
-        return false;
-      }
-    }, true);
-    
-    // 2. ドラッグ開始を防ぐ
-    document.addEventListener('dragstart', function(e) {
-      if (e.shiftKey && !isAllowedElement(e.target)) {
-        e.preventDefault();
-        e.stopPropagation();
-        e.stopImmediatePropagation();
-        return false;
-      }
-    }, true);
-
-    // 3. マウスダウン時のShiftクリックでテキスト選択を防ぐ
-    document.addEventListener('mousedown', function(e) {
-      if (e.shiftKey && !isAllowedElement(e.target)) {
-        console.log('Preventing mousedown on shift+click for:', e.target);
-        e.preventDefault();
-        e.stopPropagation();
-        e.stopImmediatePropagation();
-        clearSelection();
-        return false;
-      }
-    }, true);
-
-    // 4. マウスアップ時も防ぐ
-    document.addEventListener('mouseup', function(e) {
-      if (e.shiftKey && !isAllowedElement(e.target)) {
-        e.preventDefault();
-        e.stopPropagation();
-        e.stopImmediatePropagation();
-        clearSelection();
-        return false;
-      }
-    }, true);
-
-    // 5. クリック時も防ぐ
-    document.addEventListener('click', function(e) {
-      if (e.shiftKey && !isAllowedElement(e.target)) {
-        e.preventDefault();
-        e.stopPropagation();
-        e.stopImmediatePropagation();
-        clearSelection();
-        return false;
-      }
-    }, true);
-
-    // 6. マウス移動時に選択が発生している場合は即座にクリア
-    document.addEventListener('mousemove', function(e) {
-      if (e.shiftKey) {
-        // 選択が発生していたら即座にクリア
-        setTimeout(clearSelection, 0);
-      }
-    }, true);
-
-    // 7. 定期的に選択状態をチェック・クリア
-    setInterval(function() {
-      try {
-        if (window.getSelection) {
-          var selection = window.getSelection();
-          if (selection.rangeCount > 0 && selection.toString().length > 0) {
-            // 許可されていない選択の場合のみクリア
-            var range = selection.getRangeAt(0);
-            var container = range.commonAncestorContainer;
-            var element = container.nodeType === Node.TEXT_NODE ? container.parentNode : container;
-            
-            if (!isAllowedElement(element)) {
-              console.log('Clearing unexpected selection:', selection.toString());
-              clearSelection();
-            }
-          }
-        }
-      } catch (e) {
-        // エラーは無視
-      }
-    }, 100);
+    // CSSでテキスト選択を制御する方が確実
+    // テーブル行とボタン類のみ user-select: none を適用
+    var style = document.createElement('style');
+    style.textContent = `
+      #novel-list tbody tr { user-select: none; -webkit-user-select: none; -moz-user-select: none; }
+      .btn, button { user-select: none; -webkit-user-select: none; -moz-user-select: none; }
+      /* 入力フィールドとタグは選択可能に */
+      input, textarea, .tag[data-tag]:not(.tag-reset) { user-select: text !important; -webkit-user-select: text !important; -moz-user-select: text !important; }
+    `;
+    document.head.appendChild(style);
 
     // タグクリック処理（キャプチャフェーズで最優先処理）
     // 修飾キーによる検索モード：
@@ -2326,71 +2306,8 @@ Mac スタイル：<br>メニューが画面外にはみ出そうとしたら、
   });
 
   /*
-   * ショートカット設定
-   * http://www.openjs.com/scripts/events/keyboard_shortcuts/index.php
+   * ショートカット設定は initializeDataTable 関数の前に移動済み
    */
-  var initialize_shortcut = function() {
-    var options = {
-      disable_in_input: true,
-    };
-    var add = function() {
-      var keys = [];
-      var callback = null;
-      for (var i = 0; i < arguments.length; i++) {
-        var value = arguments[i];
-        switch (typeof value) {
-        case "string":
-          keys.push(value);
-          break;
-        case "function":
-          callback = value;
-          break;
-        default:
-          $.error("invalid arguments: unknow type");
-          break;
-        }
-      }
-      if (!callback) $.error("shortcut error: need callback");
-      for (var i = 0; i < keys.length; i++) {
-        shortcut.add(keys[i], callback, options);
-      }
-    };
-
-    var click = function(id) {
-      return function() {
-        $(id).trigger("click");
-      };
-    };
-
-    add("Ctrl+A", "Meta+A", function() { action.selectView(); });
-    add("Shift+A", function() { action.selectAll(); });
-    add("Ctrl+Shift+A", "Meta+Shift+A", function() { action.selectClear(); });
-    add("ESC", function() {
-      if ($("#rect-select-menu").is(":visible")) {
-        close_rect_select_menu_handler();
-      }
-      if (!window.context_menu.closed) {
-        window.context_menu.close();
-      }
-      else {
-        window.action.selectClear();
-      }
-    });
-    add("S", click("#action-select-mode-single"));
-    add("R", click("#action-select-mode-rect"));
-    add("H", click("#action-select-mode-hybrid"));
-    add("W", click("#action-view-novel-list-wide"));
-    add("F", click("#action-view-frozen"));
-    add("Shift+F", click("#action-view-nonfrozen"));
-    add("T", click("#action-tag-edit"));
-    add("F5", function() { 
-      console.log("F5キーによる手動強制テーブルリロード");
-      Narou.tableReload(true); 
-    });
-  };
-  if (!touchable_device) {
-    initialize_shortcut();
-  }
 
   /*
    * disabled なメニューは何もしないように

--- a/lib/web/views/layout.haml
+++ b/lib/web/views/layout.haml
@@ -15,9 +15,9 @@
     - else
       %link{:href => "//cdn.jsdelivr.net/npm/bootstrap@3.4.1/dist/css/bootstrap.min.css", :rel => "stylesheet"}/
       %link{:href => "/resources/css/default-style.css?_=#{Narou::VERSION}", :rel => "stylesheet"}/
-    %link{:href => "//cdn.datatables.net/2.3.4/css/dataTables.bootstrap.min.css", :rel => "stylesheet"}/
-    %link{:href => "//cdn.datatables.net/colreorder/2.1.2/css/colReorder.bootstrap.min.css", :rel => "stylesheet"}/
-    %link{:href => "//cdn.datatables.net/buttons/3.2.5/css/buttons.bootstrap.min.css", :rel => "stylesheet"}
+    %link{:href => "//cdn.datatables.net/2.3.4/css/dataTables.bootstrap.css", :rel => "stylesheet"}/
+    %link{:href => "//cdn.datatables.net/colreorder/2.1.2/css/colReorder.bootstrap.css", :rel => "stylesheet"}/
+    %link{:href => "//cdn.datatables.net/buttons/3.2.5/css/buttons.bootstrap.css", :rel => "stylesheet"}
     %link{:href => "//cdn.datatables.net/colvis/1.1.1/css/dataTables.colVis.css", :rel => "stylesheet"}/
     %link{:href => "//cdn.jsdelivr.net/npm/bootstrap-select@1.13.18/dist/css/bootstrap-select.min.css", :rel => "stylesheet"}/
     %link{:href => "//cdn.jsdelivr.net/npm/perfect-scrollbar@1.5.6/css/perfect-scrollbar.min.css", :rel => "stylesheet"}/
@@ -41,11 +41,11 @@
     %script{:src => "//cdn.jsdelivr.net/npm/jquery-migrate@3.5.2/dist/jquery-migrate.js"}
     %script{:src => "//cdn.jsdelivr.net/npm/bootstrap@3.4.1/dist/js/bootstrap.min.js"}
     %script{:src => "//cdn.datatables.net/2.3.4/js/dataTables.min.js"}
-    %script{:src => "//cdn.datatables.net/2.3.4/js/dataTables.bootstrap.min.js"}
+    %script{:src => "//cdn.datatables.net/2.3.4/js/dataTables.bootstrap.js"}
     %script{:src => "//cdn.datatables.net/colreorder/2.1.2/js/dataTables.colReorder.min.js"}
-    %script{:src => "//cdn.datatables.net/colreorder/2.1.2/js/colReorder.bootstrap.min.js"}
+    %script{:src => "//cdn.datatables.net/colreorder/2.1.2/js/colReorder.bootstrap.js"}
     %script{:src => "//cdn.datatables.net/buttons/3.2.5/js/dataTables.buttons.min.js"}
-    %script{:src => "//cdn.datatables.net/buttons/3.2.5/js/buttons.bootstrap.min.js"}
+    %script{:src => "//cdn.datatables.net/buttons/3.2.5/js/buttons.bootstrap.js"}
     %script{:src => "//cdn.datatables.net/buttons/3.2.5/js/buttons.colVis.min.js"}
     %script{:src => "//cdn.jsdelivr.net/npm/bootstrap-select@1.13.18/js/bootstrap-select.min.js"}
     %script{:src => "//cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js"}

--- a/lib/web/views/style.scss
+++ b/lib/web/views/style.scss
@@ -101,6 +101,7 @@ table#novel-list {
   color: $default-color;
   //border-color: darken($odd-color, 20%);
   border-color: $novel-list-border-color;
+  background-color: $even-color;
 
   @mixin dataTableSortingHeader($arrow_img_url) {
     background: url($arrow_img_url) no-repeat center right !important;
@@ -110,12 +111,16 @@ table#novel-list {
   thead {
     background-color: $thead-background-color;
     color: #ddd0cc;
+    th {
+      background-color: $thead-background-color;
+    }
   }
   td {
     padding: 4px !important;
     vertical-align: middle;
     //border-color: darken($odd-color, 20%);
     border-color: $novel-list-border-color;
+    background-color: inherit;
   }
   tr {
     td.text-center {
@@ -134,9 +139,28 @@ table#novel-list {
       background-color: #f8f3e5;
     }
   }
+  
+  /* DataTables 2.x対応: nth-childベースのストライプ */
+  tbody > tr:nth-child(odd) {
+    background-color: $odd-color;
+    td.sorting_1 {
+      background-color: #f0ecde;
+    }
+  }
+  tbody > tr:nth-child(even) {
+    background-color: $even-color;
+    td.sorting_1 {
+      background-color: #f8f3e5;
+    }
+  }
   $selected-color: mix($odd-color, rgba(255,212,0,0.5));
   //$selected-color: #90cebc;
   $selected-hover-color: #ded;
+  
+  /* DataTables 2.x のCSS変数を上書き */
+  --dt-row-selected: #{$selected-color};
+  --dt-row-selected-text: #{$default-color};
+  
   tr.selected {
     td {
       background-color: $selected-color !important;
@@ -330,6 +354,8 @@ table#novel-list {
 
 // DataTables 共通設定
 table.dataTable {
+  background-color: white;
+  
   th {
     text-align: center;
   }
@@ -340,6 +366,10 @@ table.dataTable {
     .sorting_desc_disabled {
       background: inherit;
     }
+  }
+  
+  tbody {
+    background-color: white;
   }
 }
 


### PR DESCRIPTION
[Rumia-Channel/narou](https://github.com/Rumia-Channel/narou) さんの修正コミットを取込

- 9d677a9 Shift + A や Ctrl + A による小説選択処理の動作を復旧
- ffedd6c YAMLファイルの読み込み時にSystemCallErrorを処理するための例外処理を追加
- aa70587 DataTables 2.x対応のスタイルとスクリプトの更新 
  - Gemfile.lockにx64-mingw-ucrtプラットフォー
ムを追加
  - default-style.cssにDataTablesの背景色設定を追加
  - narou.ui.jsでodd/evenクラスを明示的に指定
  - layout.hamlでDataTablesのCSSファイルを更新
  - style.scssでDataTablesのストライプと選択行のスタイルを強化