### PR TITLE
Windows 向け init 実行時の NameError を解消

### DIFF
--- a/lib/extension.rb
+++ b/lib/extension.rb
@@ -32,7 +32,10 @@ def File.write(path, string, *options, mode: nil)
   dirpath = File.dirname(path)
   FileUtils.makedirs(dirpath) unless Dir.exist?(dirpath)
   temp_path = File.join(dirpath, SecureRandom.hex(15))
-  if File.extname(path) == ".yaml" && File.basename(dirpath) != Downloader::SECTION_SAVE_DIR_NAME
+  section_dir_name = if defined?(Downloader::SECTION_SAVE_DIR_NAME)
+    Downloader::SECTION_SAVE_DIR_NAME
+  end
+  if File.extname(path) == ".yaml" && File.basename(dirpath) != section_dir_name
     backup = "#{path}.backup"
   end
 

--- a/lib/helper.rb
+++ b/lib/helper.rb
@@ -4,6 +4,7 @@
 # Copyright 2013 whiteleaf. All rights reserved.
 #
 
+require "erb"
 require "open3"
 require "time"
 require "systemu"


### PR DESCRIPTION
- Helper.erb_copy 用に erb を読み込む
- Downloader 未定義でもバックアップ判定できるよう調整