### PR TITLE
Feature/web UI table arrange

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ AllCops:
   Exclude:
     - "小説データ/**/*"
     - "trash/**/*"
-  - "narou-mod.gemspec"
+    - "narou-mod.gemspec"
     - "spec/**/*"
   DisplayCopNames: true
   TargetRubyVersion: 2.5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,15 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
+
 - `lib/` holds Ruby sources: core logic in `lib/narou/`, web helpers in `lib/web/`, and CLI subcommands under `lib/command/`.
 - `spec/` contains RSpec examples plus shared helpers in `spec/support/`.
-- CLI entry points live in `bin/narou` and `narou.rb` for local execution.
+- CLI entry points live in `bin/narou-mod` and `narou.rb` for local execution.
 - Site settings, templates, and assets reside in `webnovel/`, `preset/`, and `template/`.
 - CI and release automation are under `.circleci/` and `Rakefile` tasks.
 
 ## Build, Test, and Development Commands
+
 - `bundle install`: install gem dependencies locally.
 - `bundle exec ruby narou.rb web`: boot the local web interface for manual checks.
 - `bundle exec ruby narou.rb download <novel_id>`: fetch source content for conversion experiments.
@@ -15,25 +17,30 @@
 - `bundle exec rubocop` (add `-A` to auto-correct): enforce Ruby style and catch regressions.
 
 ## Coding Style & Naming Conventions
+
 - Use Ruby two-space indentation, single quotes for simple strings, and snake_case for files and methods.
 - Namespaces should follow `Narou::CamelCase` modules; mirror existing CLI subcommand patterns in `lib/command/`.
 - Keep new files ASCII with `# frozen_string_literal: true` at the top when applicable.
 - Run `bundle exec rubocop` and `bundle exec reek` before submitting changes.
 
 ## Testing Guidelines
+
 - Write deterministic RSpec examples in `spec/`; name files `*_spec.rb` and group contexts clearly.
 - Stub network or filesystem side effects; rely on fixtures in `spec/support/` when possible.
 - Execute `bundle exec rspec` prior to review; add focused specs for new behaviour or bug fixes.
 
 ## Commit & Pull Request Guidelines
+
 - Craft imperative commit subjects (e.g., `Add downloader retry logic`) and reference issues like `#123` when relevant.
 - Update `ChangeLog.md` for user-facing changes and summarise scope, motivation, and test notes in PR descriptions.
 - Attach screenshots or logs for web/UI work and call out migrations or breaking changes explicitly.
 
 ## Security & Configuration Tips
+
 - Keep secrets out of the tree; validate new YAML configs in `webnovel/` before shipping.
 - Follow UTF-8 defaults in entry scripts and ensure downloaded data is sanitised before conversion.
 
 ## Agent-Specific Instructions
+
 - Keep edits minimal and scoped, favour incremental fixes over sweeping refactors.
 - Respect existing public APIs and CLI behaviours; coordinate larger changes through issues first.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    narou-mod (1.6.1)
+    narou-mod (2.0.0)
       activesupport (~> 8.0, >= 8.1.0)
       bootsnap (~> 1.18, >= 1.18.6)
       csv (~> 3.3)

--- a/lib/command/setting.rb
+++ b/lib/command/setting.rb
@@ -535,6 +535,16 @@ module Command
           help: "サイトから取得したタグを自動的に小説データに追加する",
           tab: :general
         },
+        "promo-tag.enable" => {
+          type: :boolean,
+          help: "タイトルや作者から宣伝タグを除去する",
+          tab: :global
+        },
+        "promo-tag.keywords" => {
+          type: :string,
+          help: "追加で除去する宣伝タグをカンマまたは改行で指定する",
+          tab: :global
+        },
         "normalize-filename" => {
           type: :boolean,
           help: "ファイル名の文字列をNFCで正規化する。※既存データとの互換性が無くなる可能性があるので、" \

--- a/lib/command/update.rb
+++ b/lib/command/update.rb
@@ -207,6 +207,7 @@ module Command
             next
           when :none
             delete_modified_tag.call
+            downloader.apply_promo_tag_preferences!
             puts "#{data["title"]} に更新はありません"
             next unless data["_convert_failure"]
           end

--- a/lib/downloader.rb
+++ b/lib/downloader.rb
@@ -9,6 +9,7 @@ require "fileutils"
 require "ostruct"
 require "cgi"
 require_relative "narou"
+require_relative "narou/promo_tag_extractor"
 require_relative "helper"
 require_relative "sitesetting"
 require_relative "novelsetting"
@@ -752,6 +753,17 @@ class Downloader
       "length" => novel_length,
       "suspend" => suspend
     }
+
+    extracted = Narou::PromoTagExtractor.extract(title: data["title"], author: data["author"])
+    data["title"] = extracted.title
+    data["author"] = extracted.author
+    data["promo_tags"] = extracted.promo_tags
+    data["promo_tags_title"] = extracted.title_tags
+    data["promo_tags_author"] = extracted.author_tags
+    @setting["title"] = extracted.title
+    @setting["author"] = extracted.author
+    @title = extracted.title
+
     auto_add_tags = Inventory.load("local_setting")["auto-add-tags"]
     if @setting["tag"] && auto_add_tags
       clean_tag = Sanitize.fragment(@setting["tag"]).gsub(/キーワード/, '').gsub(/\"?\(\?\.\+\?\)\"?/, '').gsub(/\(\?\<?[^)]*\)/, '').strip

--- a/lib/downloader.rb
+++ b/lib/downloader.rb
@@ -754,15 +754,15 @@ class Downloader
       "suspend" => suspend
     }
 
-    extracted = Narou::PromoTagExtractor.extract(title: data["title"], author: data["author"])
-    data["title"] = extracted.title
-    data["author"] = extracted.author
-    data["promo_tags"] = extracted.promo_tags
-    data["promo_tags_title"] = extracted.title_tags
-    data["promo_tags_author"] = extracted.author_tags
-    @setting["title"] = extracted.title
-    @setting["author"] = extracted.author
-    @title = extracted.title
+  data["title_raw_latest"] = data["title"]&.dup
+  data["title_original"] = data["title_raw_latest"] || data["title"]
+    data["author_original"] = data["author"]
+
+    promo_config = Narou::PromoTagExtractor.resolve_config(novel_id: @id)
+    Narou::PromoTagExtractor.normalize_entry!(data, config: promo_config)
+    @setting["title"] = data["title"]
+    @setting["author"] = data["author"]
+    @title = data["title"]
 
     auto_add_tags = Inventory.load("local_setting")["auto-add-tags"]
     if @setting["tag"] && auto_add_tags
@@ -782,6 +782,22 @@ class Downloader
       database[@id] = data
     end
     database.save_database
+  end
+
+  def apply_promo_tag_preferences!
+    data = record
+    return false unless data
+
+    promo_config = Narou::PromoTagExtractor.resolve_config(novel_id: @id)
+    changed = Narou::PromoTagExtractor.normalize_entry!(data, config: promo_config)
+
+    if @setting
+      @setting["title"] = data["title"]
+      @setting["author"] = data["author"]
+    end
+    @title = data["title"]
+
+    changed
   end
 
   def get_novel_status

--- a/lib/lazy.rb
+++ b/lib/lazy.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+#
+# Lazy loader for stdlib / common gems used in Narou.rb
+#
+# 使い方:
+#  1) このファイルを `lib/lazy.rb` として配置
+#  2) 各ファイルの先頭で、以下のように宣言
+#       require_relative "lazy"
+#       Lazy.use :yaml, :fileutils, :open3, :tempfile
+#     ※ 明示しておくことで、可読性を維持したままオートロードされます。
+#  3) よく使うセットは `Lazy.use_default!` で一括登録可能
+#
+# 仕組み:
+#   SPECの定義に基づき、対象モジュール/クラス名に autoload を設定します。
+#   実際に参照された瞬間に require されます（スレッド非依存のCLI前提）。
+#
+module Lazy
+  module_function
+
+  # ===== 対象定義 =====
+  # into: autoload を設定する親モジュール/クラス（Object か、Symbol/Module）
+  # const: 対象の定数名（Symbol）
+  # file:  require するパス（String）
+  SPEC = {
+    # 軽いが依存の多いものは遅延対象に含める
+    yaml:       { into: Object, const: :YAML,      file: "yaml" },
+    erb:        { into: Object, const: :ERB,       file: "erb" },
+    fileutils:  { into: Object, const: :FileUtils, file: "fileutils" },
+    stringio:   { into: Object, const: :StringIO,  file: "stringio" },
+    date:       { into: Object, const: :Date,      file: "date" },
+    pathname:   { into: Object, const: :Pathname,  file: "pathname" },
+    weakref:    { into: Object, const: :WeakRef,   file: "weakref" }, 
+
+    # コスト中〜高: 遅延の効果が大きい
+    tmpdir:     { into: Dir,     const: :Tmpname,  file: "tmpdir" },
+    tempfile:   { into: Object, const: :Tempfile,  file: "tempfile" },
+    diff_lcs:   { into: Object, const: :Diff,      file: "diff/lcs" },
+    open3:      { into: Object, const: :Open3,     file: "open3" },
+    termcolorlight: { into: Object, const: :TermColorLight, file: "termcolorlight" },
+
+    # よく使う周辺
+    json:       { into: Object, const: :JSON,      file: "json" },
+    rexml:      { into: Object, const: :REXML,     file: "rexml/document" },
+    nkf:        { into: Object, const: :NKF,       file: "nkf" },
+    zip:        { into: Object, const: :Zip,       file: "zip" },
+    csv:        { into: Object, const: :CSV,       file: "csv" },
+    openssl:    { into: Object, const: :OpenSSL,   file: "openssl" },
+    uri:        { into: Object, const: :URI,       file: "uri" },
+    zlib:       { into: Object, const: :Zlib,      file: "zlib" },
+
+    # ネットワーク系
+    net_http:   { into: :Net,   const: :HTTP,      file: "net/http" },
+    socket:     { into: Object, const: :Socket,    file: "socket" },
+    base64:     { into: Object, const: :Base64,    file: "base64" },
+    digest:     { into: Object, const: :Digest,    file: "digest" },
+    digest_md5: { into: Digest, const: :MD5,       file: "digest/md5" },
+    digest_sha1:{ into: Digest, const: :SHA1,      file: "digest/sha1" },
+
+    # 開発系（デバッグ）
+    pry:        { into: Object, const: :Pry,       file: "pry", dev_only: true },
+    awesome_print: { into: Object, const: :AwesomePrint, file: "awesome_print", dev_only: true },
+
+    # OS異存系
+    etc: {
+      into: Object,
+      const: :Etc,
+      file: "etc",
+      if: -> { !Gem.win_platform? || RUBY_PLATFORM =~ /mingw|mswin|cygwin/ }
+    },
+    win32ole: {
+      into: Object,
+      const: :WIN32OLE,
+      file: "win32ole",
+      if: -> { Gem.win_platform? }
+    },
+  }.freeze
+
+  # Narou.rb での "全部入り" デフォルトセット
+  DEFAULT_SET = %i[
+    yaml fileutils stringio date pathname tempfile open3
+    json rexml nkf zip csv openssl uri net_http
+  ].freeze
+
+  # ===== 公開API =====
+  # 使用宣言。各ファイル先頭で "このファイルで使うもの" を列挙。
+  def use(*keys)
+    keys.flatten.each { |k| register(k) }
+  end
+
+  # よく使うものをまとめて設定
+  def use_default!
+    use(DEFAULT_SET)
+  end
+
+  # 明示的に今すぐ require したい場合（ホットパスでの前倒し）
+  def require_now(*keys)
+    keys.flatten.each do |k|
+      spec = SPEC.fetch(k.to_sym) { raise ArgumentError, "Lazy: unknown key: #{k.inspect}" }
+      require spec[:file]
+    end
+  end
+
+  # ===== 実装詳細 =====
+  def register(key)
+    spec = SPEC.fetch(key.to_sym) { raise ArgumentError, "Lazy: unknown key: #{key.inspect}" }
+    into_mod = resolve_into(spec[:into])
+    const    = spec[:const]
+    file     = spec[:file]
+
+    # すでに定義済みなら二重登録しない
+    return if defined?(into_mod.const_get(const))
+
+    # autoload を仕掛ける
+    into_mod.autoload(const, file)
+  end
+
+  # into が Symbol のとき、適切な親モジュールを確保する
+  def resolve_into(into)
+    case into
+    when Module
+      into
+    when Class
+      into
+    when Object
+      Object
+    when Symbol
+      name = into
+      if Object.const_defined?(name, false)
+        Object.const_get(name)
+      else
+        # 親が未定義でも autoload したい場合は空モジュールを立てる
+        Object.const_set(name, Module.new)
+      end
+    else
+      raise ArgumentError, "Lazy: unsupported :into => #{into.inspect}"
+    end
+  end
+end

--- a/lib/narou/promo_tag_extractor.rb
+++ b/lib/narou/promo_tag_extractor.rb
@@ -301,11 +301,14 @@ module Narou
       stripped = text.dup
 
       loop do
-        matched = stripped.match(/(.+?)[＠@]\s*(.+)\z/)
-        break unless matched
+        at_index = stripped.rindex(/[＠@]/)
+        break unless at_index
 
-        head = matched[1]
-        tail = matched[2]
+        head = stripped[0...at_index]
+        tail = stripped[(at_index + 1)..-1]
+        tail = tail&.lstrip
+        break unless tail && !tail.empty?
+
         segment_tags = extract_segment_tags(tail, promo_regexes: promo_regexes)
         break if segment_tags.empty?
 

--- a/lib/narou/promo_tag_extractor.rb
+++ b/lib/narou/promo_tag_extractor.rb
@@ -1,0 +1,267 @@
+# frozen_string_literal: true
+
+module Narou
+  module PromoTagExtractor
+    module_function
+
+    BRACKETS = [
+      ['\\(', '\\)'], ['\\[', '\\]'], ['【', '】'], ['（', '）'], ['〔', '〕'],
+      ['〈', '〉'], ['《', '》'], ['＜', '＞'], ['『', '』'], ['「', '」'],
+      ['｟', '｠'], ['〖', '〗']
+    ].freeze
+
+    PROMO_KEYWORDS = [
+      '書籍化', '文庫化', '単行本化', 'コミカライズ', '漫画化', 'アニメ化', '映画化',
+      'ドラマ化', 'ドラマＣＤ化', 'ドラマCD化', 'ドラマＣＤ', 'ドラマCD', 'ボイスドラマ化', 'ゲーム化',
+      'ノベライズ', 'ボイスコミック', 'オーディオブック',
+      '連載中', '連載開始', '新連載', '配信中', '公開中', '更新中', '完結', '完結済',
+      '好評発売中', '発売中', '発売', '重版', '出荷中', '予約受付中',
+      '最新話', '公開', '第\\d+巻', '第\\d+話', '配信',
+      '受賞', '受賞作', '書籍版発売中', 'コミックス発売中',
+      '書籍版', 'コミックス版', '電書版', 'kindle版',
+      'コミックス\\s*第\\d+巻'
+    ].freeze
+
+    SEP = /\s*[|｜／\/・\-—–―~〜:：;；]+?\s*/x.freeze
+    TOKEN_SEPARATOR = /\s*[|｜／\/・･\-—–―~〜:：;；＋+＠@＆&]+?\s*/x.freeze
+    TRAILING_DECORATIONS = /[！!？?。．､，,、…‥☆★♪♪※‼⁉︎〜～ー─—―・\s]+\z/.freeze
+    WHITESPACE_PATTERN = /[\s\u3000]+/.freeze
+
+    PROMO_REGEXES = PROMO_KEYWORDS.map { |pattern| Regexp.new(pattern) }.freeze
+    BRACKET_REGEXES = BRACKETS.map do |opening, closing|
+      Regexp.new("#{opening}(.*?)#{closing}")
+    end.freeze
+    SEP_CAPTURE = Regexp.new("(#{SEP.source})", SEP.options).freeze
+
+    Result = Struct.new(:title, :author, :promo_tags, :title_tags, :author_tags, keyword_init: true)
+
+    def extract(title:, author: nil)
+      sanitized_title, title_tags = cleanse(title)
+      sanitized_author, author_tags = cleanse(author)
+      promo_tags = uniq_preserve_order(title_tags + author_tags)
+      Result.new(
+        title: sanitized_title,
+        author: sanitized_author,
+        promo_tags: promo_tags,
+        title_tags: title_tags,
+        author_tags: author_tags
+      )
+    end
+
+    def normalize_entry!(entry)
+      return false unless entry.is_a?(Hash)
+
+      result = extract(title: entry["title"], author: entry["author"])
+      updated = false
+
+      if result.title != entry["title"]
+        entry["title"] = result.title
+        updated = true
+      end
+
+      if result.author != entry["author"]
+        entry["author"] = result.author
+        updated = true
+      end
+
+      promo_tags = result.promo_tags.dup
+      if promo_tags.empty? && entry["promo_tags"].is_a?(Array)
+        promo_tags = entry["promo_tags"]
+      end
+
+      if !entry["promo_tags"].is_a?(Array) || entry["promo_tags"] != promo_tags
+        entry["promo_tags"] = promo_tags
+        updated = true
+      end
+
+      existing_title_tags = entry["promo_tags_title"] if entry["promo_tags_title"].is_a?(Array)
+      existing_author_tags = entry["promo_tags_author"] if entry["promo_tags_author"].is_a?(Array)
+
+      title_tags = (result.title_tags || []).dup
+      title_tags = existing_title_tags.dup if title_tags.empty? && existing_title_tags
+      author_tags = (result.author_tags || []).dup
+      author_tags = existing_author_tags.dup if author_tags.empty? && existing_author_tags
+
+      if entry["promo_tags_title"] != title_tags
+        entry["promo_tags_title"] = title_tags
+        updated = true
+      end
+
+      if entry["promo_tags_author"] != author_tags
+        entry["promo_tags_author"] = author_tags
+        updated = true
+      end
+
+      updated
+    end
+
+    def cleanse(value)
+      original = (value || "").to_s
+      text = original.dup
+      return [normalize_spacing(original), []] if text.strip.empty?
+
+      tags = []
+
+      text, bracket_tags = strip_bracket_promos(text)
+      tags.concat(bracket_tags)
+
+      text, at_tags = strip_at_promos(text)
+      tags.concat(at_tags)
+
+      text, separated_tags = strip_separator_promos(text)
+      tags.concat(separated_tags)
+
+      normalized = normalize_spacing(text)
+      normalized = normalize_spacing(original) if normalized.empty?
+      [normalized, uniq_preserve_order(tags)]
+    end
+
+    def normalize_spacing(text)
+      text.to_s.gsub(WHITESPACE_PATTERN, " ").strip
+    end
+
+    def strip_bracket_promos(text)
+      tags = []
+      stripped = text.dup
+
+      BRACKET_REGEXES.each do |pattern|
+        loop do
+          replaced = false
+          stripped = stripped.gsub(pattern) do |match|
+            inner = Regexp.last_match(1)
+            segment_tags = extract_segment_tags(inner)
+            if segment_tags.empty? || !promotional_content?(inner)
+              match
+            else
+              tags.concat(segment_tags)
+              replaced = true
+              ""
+            end
+          end
+          break unless replaced
+        end
+      end
+
+      [stripped, tags]
+    end
+
+    def strip_at_promos(text)
+      tags = []
+      stripped = text.dup
+
+      loop do
+        matched = stripped.match(/(.+?)[＠@]\s*(.+)\z/)
+        break unless matched
+
+        head = matched[1]
+        tail = matched[2]
+        segment_tags = extract_segment_tags(tail)
+        break if segment_tags.empty?
+
+        tags.concat(segment_tags)
+        stripped = head.rstrip
+      end
+
+      [stripped, tags]
+    end
+
+    def strip_separator_promos(text)
+      tags = []
+      keep_parts = []
+      last_kept = false
+
+      segments = split_with_separators(text)
+      segments.each do |segment|
+        content = segment[:segment]
+        next if content.nil? || content.empty?
+
+        segment_tags = extract_segment_tags(content)
+        if segment_tags.empty?
+          if segment[:separator] && last_kept
+            keep_parts << segment[:separator]
+          end
+          keep_parts << content
+          last_kept = true
+        else
+          tags.concat(segment_tags)
+          last_kept = false
+        end
+      end
+
+      [keep_parts.join, tags]
+    end
+
+    def split_with_separators(text)
+      return [] if text.nil? || text.empty?
+
+      parts = text.split(SEP_CAPTURE)
+      segments = []
+      separator_buffer = nil
+
+      parts.each do |part|
+        next if part.nil? || part.empty?
+
+        if part.match?(SEP)
+          separator_buffer = part
+        else
+          segments << { separator: separator_buffer, segment: part }
+          separator_buffer = nil
+        end
+      end
+
+      segments
+    end
+
+    def extract_segment_tags(segment)
+      trimmed = normalize_spacing(segment)
+      return [] if trimmed.empty?
+
+      tokens = split_tokens(trimmed)
+
+      if tokens.size > 1 && tokens.all? { |token| promotional_token?(token) }
+        return tokens.map { |token| normalize_spacing(token) }
+      end
+
+      if tokens.size == 1 && promotional_token?(tokens.first)
+        return [normalize_spacing(tokens.first)]
+      end
+
+      return [trimmed] if promotional_token?(trimmed)
+
+      []
+    end
+
+    def split_tokens(text)
+      text.split(TOKEN_SEPARATOR).map { |token| token.strip }.reject(&:empty?)
+    end
+
+    def promotional_token?(text)
+      normalized = normalize_for_match(text)
+      return false if normalized.empty?
+
+      PROMO_REGEXES.any? { |regex| regex.match?(normalized) }
+    end
+
+    def promotional_content?(text)
+      normalized = normalize_for_match(text)
+      return false if normalized.empty?
+
+      PROMO_REGEXES.any? { |regex| regex.match?(normalized) }
+    end
+
+    def normalize_for_match(text)
+      normalize_spacing(text).gsub(TRAILING_DECORATIONS, "")
+    end
+
+    def uniq_preserve_order(list)
+      seen = {}
+      list.each_with_object([]) do |item, result|
+        next if item.nil? || item.empty?
+        next if seen[item]
+
+        seen[item] = true
+        result << item
+      end
+    end
+  end
+end

--- a/lib/narou/promo_tag_extractor.rb
+++ b/lib/narou/promo_tag_extractor.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require_relative "../inventory"
+require_relative "../novelsetting"
+
 module Narou
   module PromoTagExtractor
     module_function
@@ -10,7 +13,7 @@ module Narou
       ['｟', '｠'], ['〖', '〗']
     ].freeze
 
-    PROMO_KEYWORDS = [
+    DEFAULT_PROMO_KEYWORDS = [
       '書籍化', '文庫化', '単行本化', 'コミカライズ', '漫画化', 'アニメ化', '映画化',
       'ドラマ化', 'ドラマＣＤ化', 'ドラマCD化', 'ドラマＣＤ', 'ドラマCD', 'ボイスドラマ化', 'ゲーム化',
       'ノベライズ', 'ボイスコミック', 'オーディオブック',
@@ -22,22 +25,38 @@ module Narou
       'コミックス\\s*第\\d+巻'
     ].freeze
 
+    DEFAULT_PROMO_REGEXES = DEFAULT_PROMO_KEYWORDS.map { |pattern| Regexp.new(pattern) }.freeze
+
     SEP = /\s*[|｜／\/・\-—–―~〜:：;；]+?\s*/x.freeze
     TOKEN_SEPARATOR = /\s*[|｜／\/・･\-—–―~〜:：;；＋+＠@＆&]+?\s*/x.freeze
     TRAILING_DECORATIONS = /[！!？?。．､，,、…‥☆★♪♪※‼⁉︎〜～ー─—―・\s]+\z/.freeze
     WHITESPACE_PATTERN = /[\s\u3000]+/.freeze
 
-    PROMO_REGEXES = PROMO_KEYWORDS.map { |pattern| Regexp.new(pattern) }.freeze
     BRACKET_REGEXES = BRACKETS.map do |opening, closing|
       Regexp.new("#{opening}(.*?)#{closing}")
     end.freeze
     SEP_CAPTURE = Regexp.new("(#{SEP.source})", SEP.options).freeze
 
-    Result = Struct.new(:title, :author, :promo_tags, :title_tags, :author_tags, keyword_init: true)
+    DEFAULT_ENABLED = false
 
-    def extract(title:, author: nil)
-      sanitized_title, title_tags = cleanse(title)
-      sanitized_author, author_tags = cleanse(author)
+    Result = Struct.new(:title, :author, :promo_tags, :title_tags, :author_tags, keyword_init: true)
+    Config = Struct.new(:enabled, :keywords, :regexes, keyword_init: true)
+
+    def extract(title:, author: nil, config: nil)
+      resolved_config = build_config(config)
+      unless resolved_config.enabled
+        return Result.new(
+          title: normalize_spacing(title),
+          author: normalize_spacing(author),
+          promo_tags: [],
+          title_tags: [],
+          author_tags: []
+        )
+      end
+
+      promo_regexes = resolved_config.regexes
+      sanitized_title, title_tags = cleanse(title, promo_regexes: promo_regexes)
+      sanitized_author, author_tags = cleanse(author, promo_regexes: promo_regexes)
       promo_tags = uniq_preserve_order(title_tags + author_tags)
       Result.new(
         title: sanitized_title,
@@ -48,10 +67,21 @@ module Narou
       )
     end
 
-    def normalize_entry!(entry)
+    def normalize_entry!(entry, config: nil, novel_id: nil)
       return false unless entry.is_a?(Hash)
 
-      result = extract(title: entry["title"], author: entry["author"])
+      resolved_config = config || resolve_config(novel_id: novel_id || entry["id"])
+
+  base_title = entry["title_raw_latest"]
+  base_title = entry.fetch("title_original", nil) if base_title.nil?
+  base_title ||= entry["title"]
+
+  original_author = entry.fetch("author_original", nil) || entry["author"]
+
+  entry["title_original"] = base_title if base_title
+  entry["author_original"] = original_author if original_author
+
+  result = extract(title: base_title, author: original_author, config: resolved_config)
       updated = false
 
       if result.title != entry["title"]
@@ -65,29 +95,20 @@ module Narou
       end
 
       promo_tags = result.promo_tags.dup
-      if promo_tags.empty? && entry["promo_tags"].is_a?(Array)
-        promo_tags = entry["promo_tags"]
-      end
+      title_tags = result.title_tags.dup
+      author_tags = result.author_tags.dup
 
-      if !entry["promo_tags"].is_a?(Array) || entry["promo_tags"] != promo_tags
+      unless entry["promo_tags"] == promo_tags
         entry["promo_tags"] = promo_tags
         updated = true
       end
 
-      existing_title_tags = entry["promo_tags_title"] if entry["promo_tags_title"].is_a?(Array)
-      existing_author_tags = entry["promo_tags_author"] if entry["promo_tags_author"].is_a?(Array)
-
-      title_tags = (result.title_tags || []).dup
-      title_tags = existing_title_tags.dup if title_tags.empty? && existing_title_tags
-      author_tags = (result.author_tags || []).dup
-      author_tags = existing_author_tags.dup if author_tags.empty? && existing_author_tags
-
-      if entry["promo_tags_title"] != title_tags
+      unless entry["promo_tags_title"] == title_tags
         entry["promo_tags_title"] = title_tags
         updated = true
       end
 
-      if entry["promo_tags_author"] != author_tags
+      unless entry["promo_tags_author"] == author_tags
         entry["promo_tags_author"] = author_tags
         updated = true
       end
@@ -95,20 +116,150 @@ module Narou
       updated
     end
 
-    def cleanse(value)
+    def resolve_config(novel_id: nil)
+      global_settings = Inventory.load("local_setting")
+      force_settings = NovelSetting.load_force_settings
+      default_settings = NovelSetting.load_default_settings
+
+      keywords = DEFAULT_PROMO_KEYWORDS.dup
+      keywords.concat(coerce_keywords(global_settings["promo-tag.keywords"]))
+      keywords.concat(coerce_keywords(default_settings["promo_tag_additional_keywords"]))
+      keywords.concat(coerce_keywords(force_settings["promo_tag_additional_keywords"]))
+
+      enable = determine_enable_from_settings(
+        global_settings: global_settings,
+        force_settings: force_settings,
+        default_settings: default_settings
+      )
+
+      novel_setting = load_novel_setting(novel_id)
+      if novel_setting
+        keywords.concat(coerce_keywords(novel_setting["promo_tag_additional_keywords"]))
+        enable = determine_enable_with_novel(
+          novel_setting: novel_setting,
+          current_enable: enable,
+          global_settings: global_settings,
+          force_settings: force_settings
+        )
+      end
+
+      keywords = uniq_preserve_order(keywords)
+      Config.new(
+        enabled: enable,
+        keywords: keywords,
+        regexes: compiled_regexes_for(keywords)
+      )
+    end
+
+    def load_novel_setting(novel_id)
+      return nil unless novel_id
+      NovelSetting.create(novel_id, false, false)
+    rescue StandardError
+      nil
+    end
+
+    def determine_enable_from_settings(global_settings:, force_settings:, default_settings:)
+      if force_settings.include?("enable_promo_tag_filter")
+        force_settings["enable_promo_tag_filter"]
+      elsif global_settings.include?("promo-tag.enable")
+        global_settings["promo-tag.enable"]
+      elsif default_settings.include?("enable_promo_tag_filter")
+        default_settings["enable_promo_tag_filter"]
+      else
+        DEFAULT_ENABLED
+      end
+    end
+
+    def determine_enable_with_novel(novel_setting:, current_enable:, global_settings:, force_settings:)
+      return current_enable if force_settings.include?("enable_promo_tag_filter")
+
+      if novel_setting_override?(novel_setting)
+        novel_setting["enable_promo_tag_filter"]
+      elsif !global_settings.include?("promo-tag.enable")
+        novel_setting["enable_promo_tag_filter"]
+      else
+        current_enable
+      end
+    end
+
+    def novel_setting_override?(novel_setting)
+      ini = novel_setting_ini_section(novel_setting)
+      ini.is_a?(Hash) ? ini.key?("enable_promo_tag_filter") : ini.include?("enable_promo_tag_filter")
+    end
+
+    def novel_setting_ini_section(novel_setting)
+      novel_setting.load_setting_ini["global"]
+    rescue StandardError
+      {}
+    end
+
+    def build_config(config)
+      case config
+      when Config
+        keywords = (config.keywords || DEFAULT_PROMO_KEYWORDS).dup
+        regexes = config.regexes || compiled_regexes_for(keywords)
+        enabled = config.enabled.nil? ? DEFAULT_ENABLED : config.enabled
+        Config.new(enabled: enabled, keywords: keywords, regexes: regexes)
+      when Hash
+        base_keywords = config[:keywords] ? coerce_keywords(config[:keywords]) : DEFAULT_PROMO_KEYWORDS.dup
+        additions = coerce_keywords(config[:additional_keywords])
+        keywords = uniq_preserve_order(base_keywords + additions)
+        enabled = config.key?(:enabled) ? config[:enabled] : DEFAULT_ENABLED
+        Config.new(enabled: enabled, keywords: keywords, regexes: compiled_regexes_for(keywords))
+      else
+        Config.new(
+          enabled: DEFAULT_ENABLED,
+          keywords: DEFAULT_PROMO_KEYWORDS.dup,
+          regexes: DEFAULT_PROMO_REGEXES
+        )
+      end
+    end
+
+    def compiled_regexes_for(keywords)
+      @compiled_regex_cache ||= {}
+      cache_key = keywords.join("\u0000")
+      @compiled_regex_cache[cache_key] ||= compile_regexes(keywords)
+    end
+
+    def compile_regexes(keywords)
+      keywords.map do |pattern|
+        begin
+          Regexp.new(pattern)
+        rescue RegexpError
+          Regexp.new(Regexp.escape(pattern))
+        end
+      end
+    end
+
+    def coerce_keywords(value)
+      case value
+      when nil
+        []
+      when Array
+        value.flat_map { |item| parse_keywords(item) }
+      else
+        parse_keywords(value)
+      end
+    end
+
+    def parse_keywords(raw)
+      raw.to_s.split(/[\n,]+/).map { |keyword| normalize_spacing(keyword) }.reject(&:empty?)
+    end
+
+    def cleanse(value, promo_regexes: DEFAULT_PROMO_REGEXES)
       original = (value || "").to_s
       text = original.dup
       return [normalize_spacing(original), []] if text.strip.empty?
 
       tags = []
 
-      text, bracket_tags = strip_bracket_promos(text)
+      text, bracket_tags = strip_bracket_promos(text, promo_regexes: promo_regexes)
       tags.concat(bracket_tags)
 
-      text, at_tags = strip_at_promos(text)
+      text, at_tags = strip_at_promos(text, promo_regexes: promo_regexes)
       tags.concat(at_tags)
 
-      text, separated_tags = strip_separator_promos(text)
+      text, separated_tags = strip_separator_promos(text, promo_regexes: promo_regexes)
       tags.concat(separated_tags)
 
       normalized = normalize_spacing(text)
@@ -120,7 +271,7 @@ module Narou
       text.to_s.gsub(WHITESPACE_PATTERN, " ").strip
     end
 
-    def strip_bracket_promos(text)
+    def strip_bracket_promos(text, promo_regexes: DEFAULT_PROMO_REGEXES)
       tags = []
       stripped = text.dup
 
@@ -129,8 +280,8 @@ module Narou
           replaced = false
           stripped = stripped.gsub(pattern) do |match|
             inner = Regexp.last_match(1)
-            segment_tags = extract_segment_tags(inner)
-            if segment_tags.empty? || !promotional_content?(inner)
+            segment_tags = extract_segment_tags(inner, promo_regexes: promo_regexes)
+            if segment_tags.empty? || !promotional_content?(inner, promo_regexes: promo_regexes)
               match
             else
               tags.concat(segment_tags)
@@ -145,7 +296,7 @@ module Narou
       [stripped, tags]
     end
 
-    def strip_at_promos(text)
+    def strip_at_promos(text, promo_regexes: DEFAULT_PROMO_REGEXES)
       tags = []
       stripped = text.dup
 
@@ -155,7 +306,7 @@ module Narou
 
         head = matched[1]
         tail = matched[2]
-        segment_tags = extract_segment_tags(tail)
+        segment_tags = extract_segment_tags(tail, promo_regexes: promo_regexes)
         break if segment_tags.empty?
 
         tags.concat(segment_tags)
@@ -165,7 +316,7 @@ module Narou
       [stripped, tags]
     end
 
-    def strip_separator_promos(text)
+    def strip_separator_promos(text, promo_regexes: DEFAULT_PROMO_REGEXES)
       tags = []
       keep_parts = []
       last_kept = false
@@ -175,7 +326,7 @@ module Narou
         content = segment[:segment]
         next if content.nil? || content.empty?
 
-        segment_tags = extract_segment_tags(content)
+        segment_tags = extract_segment_tags(content, promo_regexes: promo_regexes)
         if segment_tags.empty?
           if segment[:separator] && last_kept
             keep_parts << segment[:separator]
@@ -212,21 +363,21 @@ module Narou
       segments
     end
 
-    def extract_segment_tags(segment)
+    def extract_segment_tags(segment, promo_regexes: DEFAULT_PROMO_REGEXES)
       trimmed = normalize_spacing(segment)
       return [] if trimmed.empty?
 
       tokens = split_tokens(trimmed)
 
-      if tokens.size > 1 && tokens.all? { |token| promotional_token?(token) }
+      if tokens.size > 1 && tokens.all? { |token| promotional_token?(token, promo_regexes: promo_regexes) }
         return tokens.map { |token| normalize_spacing(token) }
       end
 
-      if tokens.size == 1 && promotional_token?(tokens.first)
+      if tokens.size == 1 && promotional_token?(tokens.first, promo_regexes: promo_regexes)
         return [normalize_spacing(tokens.first)]
       end
 
-      return [trimmed] if promotional_token?(trimmed)
+      return [trimmed] if promotional_token?(trimmed, promo_regexes: promo_regexes)
 
       []
     end
@@ -235,18 +386,18 @@ module Narou
       text.split(TOKEN_SEPARATOR).map { |token| token.strip }.reject(&:empty?)
     end
 
-    def promotional_token?(text)
+    def promotional_token?(text, promo_regexes: DEFAULT_PROMO_REGEXES)
       normalized = normalize_for_match(text)
       return false if normalized.empty?
 
-      PROMO_REGEXES.any? { |regex| regex.match?(normalized) }
+      promo_regexes.any? { |regex| regex.match?(normalized) }
     end
 
-    def promotional_content?(text)
+    def promotional_content?(text, promo_regexes: DEFAULT_PROMO_REGEXES)
       normalized = normalize_for_match(text)
       return false if normalized.empty?
 
-      PROMO_REGEXES.any? { |regex| regex.match?(normalized) }
+      promo_regexes.any? { |regex| regex.match?(normalized) }
     end
 
     def normalize_for_match(text)

--- a/lib/novelsetting.rb
+++ b/lib/novelsetting.rb
@@ -311,6 +311,18 @@ class NovelSetting
       help: "作者コメントを検出する（テキストファイルを直接変換する場合のみの設定）"
     },
     {
+      name: "enable_promo_tag_filter",
+      type: :boolean,
+      value: false,
+      help: "タイトルや作者から宣伝用語を除去する"
+    },
+    {
+      name: "promo_tag_additional_keywords",
+      type: :string,
+      value: "",
+      help: "追加で除去したい宣伝用語を改行またはカンマ区切りで指定する（正規表現可）"
+    },
+    {
       name: "enable_erase_introduction",
       type: :boolean,
       value: false,

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -5,5 +5,5 @@
 #
 
 module Narou
-  VERSION = "1.6.1"
+  VERSION = "2.0.0"
 end

--- a/lib/web/appserver.rb
+++ b/lib/web/appserver.rb
@@ -741,12 +741,8 @@ class Narou::AppServer < Sinatra::Base
       # キャッシュが無い場合は新規作成
       database = Database.instance
       database_values = database.get_object.values
-      database_modified = false
 
       cached_data = database_values.map do |data|
-        entry_modified = Narou::PromoTagExtractor.normalize_entry!(data)
-        database_modified ||= entry_modified
-
         id = data["id"]
         is_frozen = Narou.novel_frozen?(id)
         tags = data["tags"] || []
@@ -824,8 +820,6 @@ class Narou::AppServer < Sinatra::Base
           length: data["length"],
         }
       end
-
-      database.save_database if database_modified
 
       # キャッシュを更新
       @@api_list_cache ||= {}

--- a/lib/web/appserver.rb
+++ b/lib/web/appserver.rb
@@ -24,6 +24,7 @@ require_relative "web_worker"
 require_relative "pushserver"
 require_relative "settingmessages"
 require_relative "server_helpers"
+require_relative "../narou/promo_tag_extractor"
 require_relative "../narou/system_updater"
 
 class Narou::AppServer < Sinatra::Base
@@ -656,10 +657,11 @@ class Narou::AppServer < Sinatra::Base
             else
               # 通常の検索フィルタリング
               search_regex = Regexp.new(Regexp.escape(word), Regexp::IGNORECASE)
-              item[:title].to_s.match?(search_regex) || 
-              item[:author].to_s.match?(search_regex) ||
+              item[:title_plain].to_s.match?(search_regex) || 
+              item[:author_plain].to_s.match?(search_regex) ||
               item[:sitename].to_s.match?(search_regex) ||
               item[:status].to_s.match?(search_regex) ||
+              item[:promo_tags].any? { |tag| tag.match?(search_regex) } ||
               item[:raw_tags].any? { |tag| tag.match?(search_regex) }
             end
           end
@@ -737,12 +739,22 @@ class Narou::AppServer < Sinatra::Base
       cached_data = @@api_list_cache[cache_key]
     else
       # キャッシュが無い場合は新規作成
-      database_values = Database.instance.get_object.values
+      database = Database.instance
+      database_values = database.get_object.values
+      database_modified = false
+
       cached_data = database_values.map do |data|
+        entry_modified = Narou::PromoTagExtractor.normalize_entry!(data)
+        database_modified ||= entry_modified
+
         id = data["id"]
         is_frozen = Narou.novel_frozen?(id)
         tags = data["tags"] || []
-        
+        promo_tags = data["promo_tags"].is_a?(Array) ? data["promo_tags"] : []
+        promo_tags_title = data["promo_tags_title"].is_a?(Array) ? data["promo_tags_title"] : []
+        promo_tags_author = data["promo_tags_author"].is_a?(Array) ? data["promo_tags_author"] : []
+        author_url = data["author_url"]
+
         # 軽量モードではタグ処理を簡素化（表示のみ）
         tags_html = if lightweight_mode
                       if tags.empty?
@@ -751,21 +763,21 @@ class Narou::AppServer < Sinatra::Base
                         # 軽量表示だが、data-tag属性は保持
                         visible_tags = tags.first(3)
                         hidden_count = tags.size > 3 ? tags.size - 3 : 0
-                        
+
                         tag_spans = visible_tags.map { |tag| %!<span class="tag-simple" data-tag="#{tag}">#{tag}</span>! }
                         result = tag_spans.join(", ")
-                        
+
                         if hidden_count > 0
                           result += %! <span class="tag-more">... (+#{hidden_count}個)</span>!
                         end
-                        
+
                         # 隠されたタグもdata-tag属性として保持（検索用）
                         if tags.size > 3
                           hidden_tags = tags[3..-1]
                           hidden_spans = hidden_tags.map { |tag| %!<span class="tag-hidden" data-tag="#{tag}" style="display:none;"></span>! }
                           result += hidden_spans.join
                         end
-                        
+
                         result + %!&nbsp;<span class="tag tag-reset label label-white" data-tag="" data-toggle="tooltip" title="タグ検索を解除">&nbsp;</span>!
                       end
                     else
@@ -776,12 +788,17 @@ class Narou::AppServer < Sinatra::Base
                         %!data-tag="" data-toggle="tooltip" title="タグ検索を解除">&nbsp;</span>!
                       end
                     end
-        
+
+        title_text = data["title"].to_s
+        author_text = data["author"].to_s
+
         {
           id: id,
           last_update: data["last_update"].to_i,
-          title: h(data["title"]),
-          author: h(data["author"]),
+          title: title_text,
+          title_plain: title_text,
+          author: h(author_text),
+          author_plain: author_text,
           sitename: data["sitename"],
           toc_url: data["toc_url"],
           novel_type: data["novel_type"] == 2 ? "短編" : "連載",
@@ -793,7 +810,12 @@ class Narou::AppServer < Sinatra::Base
             tags.include?("404") ? "削除" : nil,
             data["suspend"] ? "中断" : nil
           ].compact.join(", "),
-          download: %!<a href="/novels/#{id}/download" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-download-alt"></span></a>!,
+          promo_tags: promo_tags,
+          promo_tags_title: promo_tags_title,
+          promo_tags_author: promo_tags_author,
+          promo_tags_text: promo_tags.join(" "),
+          author_url: author_url,
+          actions: nil,
           frozen: is_frozen,
           new_arrivals_date: data["new_arrivals_date"].tap { |m| break m.to_i if m },
           general_lastup: data["general_lastup"].tap { |m| break m.to_i if m },
@@ -802,6 +824,8 @@ class Narou::AppServer < Sinatra::Base
           length: data["length"],
         }
       end
+
+      database.save_database if database_modified
 
       # キャッシュを更新
       @@api_list_cache ||= {}
@@ -878,7 +902,12 @@ class Narou::AppServer < Sinatra::Base
     
     # ソート処理
     if order_column && order_dir
-      column_names = ["id", "last_update", "general_lastup", "last_check_date", "title", "author", "sitename", "novel_type", "tags", "general_all_no", "length", "status", "toc_url"]
+      column_names = [
+        "id", "last_update", "general_lastup", "last_check_date",
+        "title", "author", "sitename", "novel_type",
+        "tags", "general_all_no", "length", "average_length",
+        "status", "actions", "frozen", "new_arrivals_date"
+      ]
       sort_column = column_names[order_column]
       if sort_column
         filtered_data.sort! do |a, b|

--- a/lib/web/public/resources/js/narou.ui.js
+++ b/lib/web/public/resources/js/narou.ui.js
@@ -6,12 +6,21 @@ var t;   // for debugging
 $(function() {
   "use strict";
 
-  var touchable_device = "ontouchstart" in window;
+  var touchable_device = (function() {
+    if (navigator.maxTouchPoints !== undefined) {
+      return navigator.maxTouchPoints > 0;
+    }
+    if (navigator.msMaxTouchPoints !== undefined) {
+      return navigator.msMaxTouchPoints > 0;
+    }
+    return "ontouchstart" in window;
+  }());
   var click_event_name = (touchable_device ? "touchstart" : "click");
   var storage = new Narou.Storage();
   var EXTERNAL_ICON_HTML = '' +
     '<span class="glyphicon glyphicon-new-window external-link-icon" aria-hidden="true"></span>' +
     '<span class="sr-only">新しいタブで開く</span>';
+  var slideNavbar = $(".navbar-collapse").slideNavbar();
 
   // refreshTooltop関数を早期に定義
   function refreshTooltop(id, title, placement) {
@@ -845,8 +854,9 @@ $(function() {
         $("#novel-list_processing").hide();
       }, 100);
 
-      // テーブル初期化完了後にactionを作成
-      window.action = new Narou.Action($('#novel-list').DataTable());
+  // テーブル初期化完了後にactionを作成
+  action = new Narou.Action($('#novel-list').DataTable());
+  window.action = action;
 
       // ソート変更時に選択状態を復元
       table.on('order.dt', function() {

--- a/lib/web/public/resources/js/narou.ui.js
+++ b/lib/web/public/resources/js/narou.ui.js
@@ -9,6 +9,9 @@ $(function() {
   var touchable_device = "ontouchstart" in window;
   var click_event_name = (touchable_device ? "touchstart" : "click");
   var storage = new Narou.Storage();
+  var EXTERNAL_ICON_HTML = '' +
+    '<span class="glyphicon glyphicon-new-window external-link-icon" aria-hidden="true"></span>' +
+    '<span class="sr-only">新しいタブで開く</span>';
 
   // refreshTooltop関数を早期に定義
   function refreshTooltop(id, title, placement) {
@@ -20,6 +23,10 @@ $(function() {
           $(e.target).tooltip("hide");
         }, 3500);
       });
+  }
+
+  function escapeHtml(text) {
+    return $("<div>").text(text == null ? "" : text).html();
   }
 
   var datatables_init_completed = false;
@@ -34,18 +41,16 @@ $(function() {
       // スマフォ系端末
       {
         id: false, last_update: false, title: true, author: false, sitename: false,
-        toc_url: false, novel_type: false, tags: false, status: false, menu: true,
-        download: true, folder: false, update_button: false, general_lastup: false,
+        novel_type: false, tags: false, status: false, actions: true,
+        general_lastup: false,
         general_all_no: false, last_check_date: false, length: false, average_length: false,
-        story: false,
       }
       // PC
     : {
         id: true, last_update: true, title: true, author: true, sitename: true,
-        toc_url: true, novel_type: false, tags: true, status: true, menu: true,
-        download: false, folder: true, update_button: true, general_lastup: true,
+        novel_type: false, tags: true, status: true, actions: true,
+        general_lastup: true,
         general_all_no: false, last_check_date: false, length: false, average_length: false,
-        story: false,
       });
 
   $.fn.dataTable.Api.register("fireChangeSelect()", function() {
@@ -478,21 +483,113 @@ $(function() {
       // タイトル
       {
         title: "タイトル",
-        data: "title", visible: cell_visible.title
+        data: "title",
+        visible: cell_visible.title,
+        render: function(title, type, row) {
+          if (type !== "display") {
+            return title;
+          }
+
+          var baseTitle = title || "";
+          var safeTitle = escapeHtml(baseTitle);
+          var linkHtml;
+          if (row.toc_url) {
+            var safeUrl = escapeHtml(row.toc_url);
+            linkHtml = '<a href="' + safeUrl + '" class="novel-title-link" target="_blank" rel="noopener noreferrer">' + safeTitle + EXTERNAL_ICON_HTML + '</a>';
+          } else {
+            linkHtml = '<span class="novel-title-link">' + safeTitle + '</span>';
+          }
+
+          var promoHtml = "";
+          var titleTags = [];
+          if (Array.isArray(row.promo_tags_title) && row.promo_tags_title.length > 0) {
+            titleTags = row.promo_tags_title;
+          } else if (Array.isArray(row.promo_tags) && row.promo_tags.length > 0) {
+            titleTags = row.promo_tags;
+          }
+
+          if (titleTags.length > 0) {
+            var queryBase = row.title_plain || baseTitle;
+            promoHtml = '<div class="promo-tags">';
+            titleTags.forEach(function(tag) {
+              var safeTag = escapeHtml(tag);
+              var query = encodeURIComponent((queryBase || "") + " " + tag);
+              var aria = escapeHtml((queryBase || "") + " と " + tag + " を検索");
+              promoHtml += '<a class="promo-tag" href="https://www.google.com/search?q=' + query + '" target="_blank" rel="noopener noreferrer" aria-label="' + aria + '">' + safeTag + '</a>';
+            });
+            promoHtml += "</div>";
+          }
+
+          return '<div class="novel-title-cell">' + linkHtml + promoHtml + '</div>';
+        }
       },
       // 作者名
       {
         title: "作者名",
         data: "author", visible: cell_visible.author,
-        width: "100px",
+        width: "140px",
         render: function(author, type, row) {
-          if (author && type === "display") {
-            return sprintf(
-              '<span class="add-filter" data-add-filter="%(author)s">%(author)s</span>',
-              { author: author }
-            );
+          if (type !== "display") {
+            return author;
           }
-          return author;
+
+          var baseAuthor = author || "";
+          if (!baseAuthor) {
+            return "";
+          }
+
+          var authorPlain = row.author_plain || baseAuthor;
+          var safeAuthor = escapeHtml(baseAuthor);
+          var safeAuthorPlain = escapeHtml(authorPlain);
+
+          var authorLink;
+          if (row.author_url) {
+            var safeUrl = escapeHtml(row.author_url);
+            authorLink = '<a href="' + safeUrl + '" class="author-link" target="_blank" rel="noopener noreferrer">' + safeAuthor + EXTERNAL_ICON_HTML + '</a>';
+          } else {
+            authorLink = '<span class="author-text add-filter" data-add-filter="' + safeAuthorPlain + '">' + safeAuthor + '</span>';
+          }
+
+          var filterButton = "";
+          if (row.author_url) {
+            filterButton = '' +
+              '<button type="button" class="author-filter-button" data-add-filter="' + safeAuthorPlain + '"' +
+              ' title="著者で絞り込む">' +
+              '<span class="glyphicon glyphicon-filter" aria-hidden="true"></span>' +
+              '<span class="sr-only">著者で絞り込む</span>' +
+              '</button>';
+          }
+
+          var authorTags = [];
+          if (Array.isArray(row.promo_tags_author) && row.promo_tags_author.length > 0) {
+            authorTags = row.promo_tags_author;
+          } else if (!Array.isArray(row.promo_tags_author) && Array.isArray(row.promo_tags) && !row.promo_tags_title) {
+            authorTags = row.promo_tags;
+          }
+
+          var tagsHtml = "";
+          if (authorTags.length > 0) {
+            var queryBase = authorPlain || baseAuthor;
+            tagsHtml = '<div class="promo-tags">';
+            authorTags.forEach(function(tag) {
+              var safeTag = escapeHtml(tag);
+              var query = encodeURIComponent((queryBase || "") + " " + tag);
+              var aria = escapeHtml((queryBase || "") + " と " + tag + " を検索");
+              tagsHtml += '<a class="promo-tag" href="https://www.google.com/search?q=' + query + '" target="_blank" rel="noopener noreferrer" aria-label="' + aria + '">' + safeTag + '</a>';
+            });
+            tagsHtml += "</div>";
+          }
+
+          var cellHtml = '<div class="author-cell">';
+          cellHtml += '<div class="author-main">' + authorLink;
+          if (filterButton) {
+            cellHtml += filterButton;
+          }
+          cellHtml += '</div>';
+          cellHtml += tagsHtml;
+          cellHtml += '</div>';
+
+          return cellHtml;
         }
       },
       // 掲載サイト
@@ -570,116 +667,102 @@ $(function() {
         orderable: false, searchable: false,
         width: "30px"
       },
-      // 掲載URL
+      // 操作
       {
-        title: "リンク",
-        data: "toc_url", className: "text-center",
-        visible: cell_visible.toc_url,
-        orderable: false, searchable: false,
-        width: "25px",
-        render: function(data, type, row) {
-          if (!data) return "";
-
-          switch (type) {
-          case "display":
-            return sprintf(
-                '<a href="%(url)s" class="btn btn-default btn-xs" target="_blank" rel="noreferrer" ' +
-                'data-toggle="tooltip" data-placement="top" title="%(url)s">' +
-                '<span class="glyphicon glyphicon-link"></span></a>',
-                { url: data }
-              );
-
-          case "filter":
-          case "sort":
-            return data;
+        title: "操作",
+        data: "actions",
+        className: "text-center column-actions",
+        orderable: false,
+        searchable: false,
+        visible: cell_visible.actions,
+  width: "120px",
+        render: function(data, type) {
+          if (type === "display") {
+            return "";
           }
-
           return data;
-        }
-      },
-      // 書籍データDLリンク
-      {
-        title: "ＤＬ",
-        data: "download", className: "text-center", orderable: false,
-        searchable: false, visible: cell_visible.download,
-        width: "25px"
-      },
-      {
-        title: "保存先",
-        data: "folder", className: "text-center", orderable: false,
-        searchable: false, visible: cell_visible.folder,
-        width: "25px",
-        defaultContent: '<button class="btn btn-default btn-xs">' +
-                        '<span class="glyphicon glyphicon-folder-open"></span></button>',
-        createdCell: function(td, cellData, rowData, rowIndex, colIndex) {
-          $(td).children("button")
-            .data("targetId", rowData.id)
+        },
+        createdCell: function(td, cellData, rowData) {
+          var buttonsHtml = '' +
+            '<div class="action-button-group">' +
+              '<a class="btn btn-default btn-xs action-download" ' +
+                'data-toggle="tooltip" title="書籍データをダウンロード" target="_blank" rel="noopener noreferrer">' +
+                '<span class="glyphicon glyphicon-download-alt"></span>' +
+              '</a>' +
+              '<button type="button" class="btn btn-default btn-xs action-folder" ' +
+                'data-toggle="tooltip" title="保存フォルダを開く">' +
+                '<span class="glyphicon glyphicon-folder-open"></span>' +
+              '</button>' +
+              '<button type="button" class="btn btn-default btn-xs action-update" ' +
+                'data-toggle="tooltip" title="強制更新">' +
+                '<span class="glyphicon glyphicon-refresh"></span>' +
+              '</button>' +
+              '<button type="button" class="btn btn-default btn-xs action-story n-popover" ' +
+                'data-toggle="tooltip" title="あらすじを表示">' +
+                '<span class="glyphicon glyphicon-info-sign"></span>' +
+              '</button>' +
+              '<button type="button" class="btn btn-default btn-xs action-menu" ' +
+                'data-toggle="tooltip" title="個別メニュー">' +
+                '<span class="glyphicon glyphicon-option-horizontal"></span>' +
+              '</button>' +
+            '</div>';
+
+          var $td = $(td);
+          $td.html(buttonsHtml);
+
+          var targetId = rowData.id;
+          var downloadUrl = '/novels/' + targetId + '/download';
+
+          $td.find('.action-download')
+            .attr('href', downloadUrl)
+            .on('click', function(e) {
+              e.stopPropagation();
+            });
+
+          $td.find(".action-folder")
+            .data("targetId", targetId)
             .on("click", function(e) {
               e.stopPropagation();
-              var $this = $(this);
-              var target_id = $this.data("targetId");
-              window.action.folder(target_id);
+              var id = $(this).data("targetId");
+              if (window.action && window.action.folder) {
+                window.action.folder(id);
+              }
             });
-        },
-        render: function() {}
-      },
-      {
-        title: "更新",
-        data: "update_button", className: "text-center", orderable: false,
-        searchable: false, visible: cell_visible.update_button,
-        defaultContent: '<button class="btn btn-default btn-xs">' +
-                        '<span class="glyphicon glyphicon-refresh"></span></button>',
-        width: "25px",
-        createdCell: function(td, cellData, rowData, rowIndex, colIndex) {
-          $(td).children("button")
-            .data("targetId", rowData.id)
+
+          $td.find(".action-update")
+            .data("targetId", targetId)
             .on("click", function(e) {
               e.stopPropagation();
-              var $this = $(this);
-              var target_id = $this.data("targetId");
-              window.action.updateForce(target_id);
+              var id = $(this).data("targetId");
+              if (window.action && window.action.updateForce) {
+                window.action.updateForce(id);
+              }
             });
-        },
-        render: function() {}
-      },
-      // あらすじ
-      {
-        title: "あらすじ",
-        data: "story", visible: cell_visible.story, className: "text-center",
-        searchable: false, orderable: false,
-        width: "25px",
-        render: function () {},
-        defaultContent: '<button class="btn btn-default btn-xs n-popover">' +
-                        '<span class="glyphicon glyphicon-info-sign"></span></button>',
-        createdCell: function(td, cellData, rowData, rowIndex, colIndex) {
-          var popoverToggled = false;
-          var beforeTargetId = null;
-          $(td).children("button")
-            .data("targetId", rowData.id)
+
+          var $storyButton = $td.find(".action-story");
+          $storyButton
+            .data("targetId", targetId)
             .one("click", function(e) {
+              e.stopPropagation();
               var $this = $(this);
-              var targetId = $this.data("targetId");
-              window.action.displayStory($this, targetId);
+              var id = $this.data("targetId");
+              if (window.action && window.action.displayStory) {
+                window.action.displayStory($this, id);
+              }
             })
-        },
-      },
-      {
-        title: "個別",
-        data: "menu", className: "text-center",
-        defaultContent: '<button class="btn btn-default btn-xs">' +
-                        '<span class="glyphicon glyphicon-option-horizontal"></span></button>',
-        visible: cell_visible.menu,
-        width: "25px",
-        createdCell: function(td, cellData, rowData, rowIndex, colIndex) {
-          $(td).children("button")
-            .data("targetId", rowData.id)
             .on("click", function(e) {
               e.stopPropagation();
-              openContextMenuWithTr($(e.target).closest("tr"), e);
             });
-        },
-        render: function() {},
-        searchable: false, orderable: false,
+
+          var trElement = $(td).closest('tr').get(0);
+
+          $td.find(".action-menu")
+            .data("targetId", targetId)
+            .on("click", function(e) {
+              e.stopPropagation();
+              openContextMenuWithTr(trElement, e);
+            });
+        }
       },
       // 凍結状態（内部データ用）
       {

--- a/lib/web/server_helpers.rb
+++ b/lib/web/server_helpers.rb
@@ -7,9 +7,11 @@
 # rubocop:disable Style/ClassAndModuleChildren
 
 require "json"
+require_relative "../novelsetting"
 
 module Narou::ServerHelpers
   RELOAD_TIMING_DEFAULT = "every"
+  FORCE_SETTING_DEFAULT_HINT = "未設定時：個別設定や default.* の値がそのまま利用されます".freeze
 
   #
   # タグをHTMLで装飾する
@@ -275,6 +277,81 @@ module Narou::ServerHelpers
 
   def table_reload_timing
     Inventory.load("local_setting")["webui.table.reload-timing"] || RELOAD_TIMING_DEFAULT
+  end
+
+  def default_hint_for_setting(name, definition)
+    hint_map = if Narou.const_defined?(:SETTING_VARIABLES_WEBUI_DEFAULT_HINTS)
+                 Narou::SETTING_VARIABLES_WEBUI_DEFAULT_HINTS
+               else
+                 {}
+               end
+    hint = hint_map[name]
+    return hint if hint
+
+    if name.start_with?("default_args.")
+      command_name = name.split(".", 2).last
+      return "未設定時：#{command_name} コマンドに追加の既定オプションは付与されません"
+    end
+
+    case definition[:tab]
+    when :default
+      if name == "default.enable_promo_tag_filter"
+        return "未設定時：いいえ"
+      end
+      original_key = name.sub(/^default\./, "")
+      original = original_setting_definition(original_key)
+      return nil unless original
+      formatted = format_setting_value(original[:value], original)
+      "未設定時：#{formatted}"
+    when :force
+      FORCE_SETTING_DEFAULT_HINT
+    else
+      nil
+    end
+  end
+
+  def format_setting_value(value, definition = nil)
+    case definition && definition[:type]
+    when :select
+      summary = select_summary(definition, value)
+      return summary if summary
+    when :multiple
+      values = Array(value)
+      return "未設定" if values.empty?
+      formatted_values = values.map do |entry|
+        select_summary(definition, entry) || format_setting_value(entry)
+      end
+      return formatted_values.join(", ")
+    when :boolean
+      return value_to_msg(value)
+    end
+
+    case value
+    when TrueClass, FalseClass
+      value_to_msg(value)
+    when Array
+      return "未設定" if value.empty?
+      value.map { |entry| format_setting_value(entry) }.join(", ")
+    when NilClass
+      "未設定"
+    else
+      str = value.to_s
+      str.empty? ? "（空文字）" : str
+    end
+  end
+
+  def select_summary(definition, value)
+    keys = definition[:select_keys]
+    summaries = definition[:select_summaries]
+    return nil unless keys && summaries
+    index = keys.index(value)
+    index ? summaries[index] : nil
+  end
+
+  def original_setting_definition(setting_name)
+    index = NovelSetting::ORIGINAL_SETTINGS_KEY_INDEXES[setting_name]
+    return nil unless index
+    NovelSetting::ORIGINAL_SETTINGS[index]
   end
 
   def partial(template, *args)

--- a/lib/web/settingmessages.rb
+++ b/lib/web/settingmessages.rb
@@ -30,6 +30,12 @@ module Narou
     "convert.add-dc-subject-to-epub" => "EPUB変換時にstandard.opfファイルにdc:subject要素を追加する。\n小説のタグ情報がdc:subjectとして埋め込まれ、\n電子書籍リーダーでの検索やカテゴリ分類に活用できます。\n除外するタグは下の設定で指定できます",
     "convert.dc-subject-exclude-tags" => "dc:subjectに埋め込まないタグをカンマ区切りで指定します。\n<b>初期値:</b> 404,end（初回実行時に自動設定）\n<b>404:</b> 削除された小説に付くタグ\n<b>end:</b> 完結を示すタグ\n※すべてのタグを埋め込みたい場合は空欄にしてください",
     "convert.copy-zip-to" => "i文庫用などで生成したZIPを、変換完了時にコピーするフォルダを指定",
-    "convert.make-zip" => "ZIPファイルを出力するかどうか（対応端末: i文庫）",
+  "convert.make-zip" => "ZIPファイルを出力するかどうか（対応端末: i文庫）",
   }
+
+  SETTING_VARIABLES_WEBUI_DEFAULT_HINTS = {
+    "webui.theme" => "未設定時：CDN 配信のデフォルト Bootstrap 3 テーマを使用します",
+    "webui.performance-mode" => "未設定時：auto が適用されます",
+    "webui.table.reload-timing" => "未設定時：１作品ごとに更新します",
+  }.freeze
 end

--- a/lib/web/views/_about.haml
+++ b/lib/web/views/_about.haml
@@ -3,8 +3,11 @@
     var action = new Narou.Action;
 
     function checkVersionIsUpdated(latest, current) {
-      var latestNumbers = latest.split(".");
-      var currentNumbers = current.split(".");
+      if (!latest || !current) {
+        return false;
+      }
+      var latestNumbers = String(latest).split(".");
+      var currentNumbers = String(current).split(".");
       var maxVersionLength = Math.max(latestNumbers.length, currentNumbers.length);
       for (var i = 0; i < maxVersionLength; i++) {
         var leftNum = latestNumbers[i] | 0;
@@ -166,9 +169,6 @@
     %strong Narou.rb MOD
   %div
     Version #{@narourb_version}
-  %div
-    Copyright © 2013-#{Narou.last_commit_year} whiteleaf. All rights reserved.
-    %small (Modified by ponponusa)
   #result-of-version-checking(style="margin-top:10px")
     .checking
       %p.rotate-progress
@@ -200,6 +200,10 @@
         最新バージョンの取得に失敗しました。
 
   %pre#gem-result-log.log-box
+
+  %div
+    Copyright © 2013-#{Narou.last_commit_year} whiteleaf. All rights reserved.
+    %small (Modified by ponponusa)
 
   .well.well-sm(style="font-size:80%; margin-top: 10px")
     #{@ruby_version}<br>

--- a/lib/web/views/settings.haml
+++ b/lib/web/views/settings.haml
@@ -88,6 +88,7 @@
                     message = message.gsub("%%ORIG%%", value[:help]) if msg_for_web
                     message = message.strip.gsub("\n", "<br>")
                     error_style = { class: "has-error", style: "background-color: #f2dede" }
+                    default_hint = default_hint_for_setting(name, value)
                   .list-group-item.form-group{@error_list[name] ? error_style : {}}
                     %h4.list-group-item-heading #{name}
                     .list-group-item-text
@@ -139,6 +140,10 @@
                         - need_clear = true
                       %p
                         = message != "" ? message : "&nbsp;"
+                      - if default_hint
+                        .help-extra-messages
+                          %p
+                            = default_hint
                       - if @error_list[name]
                         %p.alert-danger
                           = @error_list[name]

--- a/lib/web/views/style.scss
+++ b/lib/web/views/style.scss
@@ -55,11 +55,7 @@ a:hover {
   overflow: hidden;
   outline: none;
 }
-
 .centering {
-  left: 0;
-  right: 0;
-  margin-left: auto;
   margin-right: auto;
 }
 
@@ -113,6 +109,7 @@ table#novel-list {
     color: #ddd0cc;
     th {
       background-color: $thead-background-color;
+      text-align: left;
     }
   }
   td {
@@ -203,6 +200,111 @@ table#novel-list {
       }
     }
   }
+
+  .novel-title-cell {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .novel-title-link {
+    font-weight: inherit;
+    color: inherit;
+    text-decoration: none;
+
+    &:hover,
+    &:focus {
+      text-decoration: underline;
+    }
+  }
+
+  .external-link-icon {
+    margin-left: 4px;
+    font-size: 0.78em;
+    line-height: 1;
+    vertical-align: baseline;
+    font-weight: 400;
+    opacity: 0.75;
+  }
+
+  .author-cell {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .author-main {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .author-link {
+    color: inherit;
+    text-decoration: none;
+
+    &:hover,
+    &:focus {
+      text-decoration: underline;
+    }
+  }
+
+  .author-filter-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    border: none;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+
+    &:hover,
+    &:focus {
+      color: #1e3f6f;
+      text-decoration: none;
+    }
+
+    .glyphicon {
+      font-size: 11px;
+      line-height: 1;
+    }
+  }
+
+  .promo-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+
+  .promo-tag {
+    display: inline-flex;
+    align-items: center;
+    padding: 1px 8px;
+    border-radius: 999px;
+    font-size: 0.9rem;
+    background-color: rgba(32, 74, 135, 0.16);
+    color: #1e3f6f;
+    text-decoration: none;
+    line-height: 1.4;
+
+    &:hover,
+    &:focus {
+      background-color: rgba(32, 74, 135, 0.28);
+      text-decoration: none;
+    }
+  }
+
+  .column-actions {
+    .action-button-group {
+      display: inline-flex;
+      gap: 4px;
+    }
+
+    .btn {
+      padding: 2px 6px;
+    }
+  }
   $frozen-color: #6caddd;
   tr.frozen td {
     $frozen-background-color: color.mix($even-color, $frozen-color, 88%);
@@ -248,8 +350,6 @@ table#novel-list {
   }
 
   /* 最新話更新日 */
-  .general-lastup {
-  }
   /* 60分以内 */
   .gl-60minutes {
     &::after {
@@ -321,8 +421,6 @@ table#novel-list {
     }
   }
   /* 上記の日付以上を過ぎている */
-  .gl-other {
-  }
 
   .hint-new-arrival {
     position: relative;
@@ -408,11 +506,7 @@ table.dataTable {
       a {
         padding-left: 4px !important;
       }
-      a:hover {
-      }
       @media (max-width:767px) {
-        a:hover {
-        }
       }
       span.active-ok {
         display: inline;
@@ -939,12 +1033,6 @@ $console-color: white;
   top: -3px;
 }
 
-.queue__size {
-}
-
-.queue__size--default {
-}
-
 .queue__size--divider {
   padding-right: 1px;
   padding-left: 1px;
@@ -954,9 +1042,6 @@ $console-color: white;
   &::before {
     content: ':';
   }
-}
-
-.queue__size--convert {
 }
 
 /*

--- a/lib/web/views/style.scss
+++ b/lib/web/views/style.scss
@@ -326,6 +326,7 @@ table#novel-list {
     color: color.adjust($frozen-color, $lightness: -20%);
   }
   thead {
+    white-space: nowrap;
     .sorting_asc {
       @include dataTableSortingHeader("/resources/images/sort_asc.png");
     }

--- a/spec/promo_tag_extractor_spec.rb
+++ b/spec/promo_tag_extractor_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "narou/promo_tag_extractor"
+
+describe Narou::PromoTagExtractor do
+  describe ".extract" do
+    it "タイトルと作者の宣伝文言を取り除き、タグとして集約する" do
+      result = described_class.extract(
+        title: "【書籍化！】サンプル小説【アニメ化！】",
+        author: "作者【受賞】"
+      )
+
+      expect(result.title).to eq("サンプル小説")
+      expect(result.author).to eq("作者")
+      expect(result.title_tags).to eq(["書籍化！", "アニメ化！"])
+      expect(result.author_tags).to eq(["受賞"])
+      expect(result.promo_tags).to eq(["書籍化！", "アニメ化！", "受賞"])
+    end
+
+    it "タグのみで構成されるタイトルは元の文字列を維持する" do
+      source = "【書籍化！】"
+      result = described_class.extract(title: source, author: nil)
+
+      expect(result.title).to eq(source)
+      expect(result.title_tags).to eq(["書籍化！"])
+      expect(result.promo_tags).to eq(["書籍化！"])
+    end
+
+    it "余分な空白を整形する" do
+      result = described_class.extract(title: "  【新連載】  テスト　タイトル  ", author: nil)
+
+      expect(result.title).to eq("テスト タイトル")
+      expect(result.title_tags).to eq(["新連載"])
+      expect(result.promo_tags).to eq(["新連載"])
+    end
+
+    it "サンプルの宣伝文言を抽出してタイトルと著者を整形する" do
+      title = "【書籍化決定！＋コミカライズ連載中】超弩級チート悪役令嬢の華麗なる復讐譚【完結済】"
+      author = "みなと＠書籍版発売中！"
+      result = described_class.extract(title: title, author: author)
+
+      expect(result.title).to eq("超弩級チート悪役令嬢の華麗なる復讐譚")
+      expect(result.author).to eq("みなと")
+      expect(result.title_tags).to eq(["書籍化決定！", "コミカライズ連載中", "完結済"])
+      expect(result.author_tags).to eq(["書籍版発売中！"])
+      expect(result.promo_tags).to eq(["書籍化決定！", "コミカライズ連載中", "完結済", "書籍版発売中！"])
+    end
+
+    it "作品中の強調がプロモタグとして扱われない" do
+      title = "ハズレ枠の【状態異常スキル】で最強になった俺がすべてを蹂躙するまで"
+      result = described_class.extract(title: title, author: nil)
+
+      expect(result.title).to eq(title)
+      expect(result.title_tags).to be_empty
+      expect(result.promo_tags).to be_empty
+    end
+
+    it "作品中のルビ風表記を保持する" do
+      title = "ゲーム世界転生〈ダン活〉～ゲーマーは【ダンジョン就活のススメ】を 〈はじめから〉プレイする～"
+      result = described_class.extract(title: title, author: nil)
+
+      expect(result.title).to eq(title)
+      expect(result.title_tags).to be_empty
+      expect(result.promo_tags).to be_empty
+    end
+
+    it "タイトル本文を誤って削除しない" do
+      source = "王都の不思議な隠れ家～晴れて離婚した令嬢は…～"
+      result = described_class.extract(title: source, author: nil)
+
+      expect(result.title).to eq(source)
+      expect(result.promo_tags).to be_empty
+    end
+  end
+
+  describe ".normalize_entry!" do
+    let(:entry) do
+      {
+        "title" => "【書籍化！】サンプル【アニメ化！】",
+        "author" => "著者【受賞】",
+        "promo_tags" => ["古いタグ"],
+        "promo_tags_title" => ["古いタグ"],
+        "promo_tags_author" => ["古いタグ"]
+      }
+    end
+
+    it "エントリを正規化し promo_tags を更新する" do
+      updated = described_class.normalize_entry!(entry)
+
+      expect(updated).to be true
+      expect(entry["title"]).to eq("サンプル")
+      expect(entry["author"]).to eq("著者")
+      expect(entry["promo_tags"]).to eq(["書籍化！", "アニメ化！", "受賞"])
+      expect(entry["promo_tags_title"]).to eq(["書籍化！", "アニメ化！"])
+      expect(entry["promo_tags_author"]).to eq(["受賞"])
+    end
+
+    it "変更がない場合は false を返す" do
+      described_class.normalize_entry!(entry)
+      updated = described_class.normalize_entry!(entry)
+
+      expect(updated).to be false
+    end
+  end
+end

--- a/spec/promo_tag_extractor_spec.rb
+++ b/spec/promo_tag_extractor_spec.rb
@@ -4,10 +4,13 @@ require "narou/promo_tag_extractor"
 
 describe Narou::PromoTagExtractor do
   describe ".extract" do
+    let(:enabled_config) { described_class.build_config(enabled: true) }
+
     it "タイトルと作者の宣伝文言を取り除き、タグとして集約する" do
       result = described_class.extract(
         title: "【書籍化！】サンプル小説【アニメ化！】",
-        author: "作者【受賞】"
+        author: "作者【受賞】",
+        config: enabled_config
       )
 
       expect(result.title).to eq("サンプル小説")
@@ -19,7 +22,7 @@ describe Narou::PromoTagExtractor do
 
     it "タグのみで構成されるタイトルは元の文字列を維持する" do
       source = "【書籍化！】"
-      result = described_class.extract(title: source, author: nil)
+      result = described_class.extract(title: source, author: nil, config: enabled_config)
 
       expect(result.title).to eq(source)
       expect(result.title_tags).to eq(["書籍化！"])
@@ -27,7 +30,11 @@ describe Narou::PromoTagExtractor do
     end
 
     it "余分な空白を整形する" do
-      result = described_class.extract(title: "  【新連載】  テスト　タイトル  ", author: nil)
+      result = described_class.extract(
+        title: "  【新連載】  テスト　タイトル  ",
+        author: nil,
+        config: enabled_config
+      )
 
       expect(result.title).to eq("テスト タイトル")
       expect(result.title_tags).to eq(["新連載"])
@@ -37,7 +44,7 @@ describe Narou::PromoTagExtractor do
     it "サンプルの宣伝文言を抽出してタイトルと著者を整形する" do
       title = "【書籍化決定！＋コミカライズ連載中】超弩級チート悪役令嬢の華麗なる復讐譚【完結済】"
       author = "みなと＠書籍版発売中！"
-      result = described_class.extract(title: title, author: author)
+      result = described_class.extract(title: title, author: author, config: enabled_config)
 
       expect(result.title).to eq("超弩級チート悪役令嬢の華麗なる復讐譚")
       expect(result.author).to eq("みなと")
@@ -48,7 +55,7 @@ describe Narou::PromoTagExtractor do
 
     it "作品中の強調がプロモタグとして扱われない" do
       title = "ハズレ枠の【状態異常スキル】で最強になった俺がすべてを蹂躙するまで"
-      result = described_class.extract(title: title, author: nil)
+      result = described_class.extract(title: title, author: nil, config: enabled_config)
 
       expect(result.title).to eq(title)
       expect(result.title_tags).to be_empty
@@ -57,7 +64,7 @@ describe Narou::PromoTagExtractor do
 
     it "作品中のルビ風表記を保持する" do
       title = "ゲーム世界転生〈ダン活〉～ゲーマーは【ダンジョン就活のススメ】を 〈はじめから〉プレイする～"
-      result = described_class.extract(title: title, author: nil)
+      result = described_class.extract(title: title, author: nil, config: enabled_config)
 
       expect(result.title).to eq(title)
       expect(result.title_tags).to be_empty
@@ -66,10 +73,40 @@ describe Narou::PromoTagExtractor do
 
     it "タイトル本文を誤って削除しない" do
       source = "王都の不思議な隠れ家～晴れて離婚した令嬢は…～"
-      result = described_class.extract(title: source, author: nil)
+      result = described_class.extract(title: source, author: nil, config: enabled_config)
 
       expect(result.title).to eq(source)
       expect(result.promo_tags).to be_empty
+    end
+
+    it "設定を有効にしない限り宣伝文言を保持する" do
+      result = described_class.extract(
+        title: "【書籍化！】サンプル小説",
+        author: "作者【受賞】"
+      )
+
+      expect(result.title).to eq("【書籍化！】サンプル小説")
+      expect(result.author).to eq("作者【受賞】")
+      expect(result.promo_tags).to be_empty
+      expect(result.title_tags).to be_empty
+      expect(result.author_tags).to be_empty
+    end
+
+    it "設定で追加したキーワードを除去する" do
+      config = described_class.build_config(
+        keywords: described_class::DEFAULT_PROMO_KEYWORDS + ["限定特典"],
+        enabled: true
+      )
+
+      result = described_class.extract(
+        title: "【限定特典】サンプルタイトル",
+        author: nil,
+        config: config
+      )
+
+      expect(result.title).to eq("サンプルタイトル")
+      expect(result.title_tags).to eq(["限定特典"])
+      expect(result.promo_tags).to eq(["限定特典"])
     end
   end
 
@@ -78,14 +115,18 @@ describe Narou::PromoTagExtractor do
       {
         "title" => "【書籍化！】サンプル【アニメ化！】",
         "author" => "著者【受賞】",
+        "title_raw_latest" => "【書籍化！】サンプル【アニメ化！】",
+        "title_original" => nil,
+        "author_original" => nil,
         "promo_tags" => ["古いタグ"],
         "promo_tags_title" => ["古いタグ"],
         "promo_tags_author" => ["古いタグ"]
       }
     end
+    let(:enabled_config) { described_class.build_config(enabled: true) }
 
     it "エントリを正規化し promo_tags を更新する" do
-      updated = described_class.normalize_entry!(entry)
+      updated = described_class.normalize_entry!(entry, config: enabled_config)
 
       expect(updated).to be true
       expect(entry["title"]).to eq("サンプル")
@@ -93,13 +134,54 @@ describe Narou::PromoTagExtractor do
       expect(entry["promo_tags"]).to eq(["書籍化！", "アニメ化！", "受賞"])
       expect(entry["promo_tags_title"]).to eq(["書籍化！", "アニメ化！"])
       expect(entry["promo_tags_author"]).to eq(["受賞"])
+    expect(entry["title_original"]).to eq("【書籍化！】サンプル【アニメ化！】")
+    expect(entry["author_original"]).to eq("著者【受賞】")
+    expect(entry["title_raw_latest"]).to eq("【書籍化！】サンプル【アニメ化！】")
     end
 
     it "変更がない場合は false を返す" do
-      described_class.normalize_entry!(entry)
-      updated = described_class.normalize_entry!(entry)
+      described_class.normalize_entry!(entry, config: enabled_config)
+      updated = described_class.normalize_entry!(entry, config: enabled_config)
 
       expect(updated).to be false
+    end
+
+    it "除去を無効化した場合は既存の値を保持する" do
+      original = Marshal.load(Marshal.dump(entry))
+
+      updated = described_class.normalize_entry!(entry, config: described_class.build_config(enabled: false))
+
+      expect(updated).to be true
+      expect(entry["title"]).to eq(original["title"])
+      expect(entry["author"]).to eq(original["author"])
+      expect(entry["promo_tags"]).to eq([])
+      expect(entry["promo_tags_title"]).to eq([])
+      expect(entry["promo_tags_author"]).to eq([])
+  expect(entry["title_original"]).to eq(original["title_raw_latest"])
+  expect(entry["title_raw_latest"]).to eq(original["title_raw_latest"])
+    end
+
+    it "オリジナルのタイトルから再適用できる" do
+      entry = {
+        "title" => "サンプル",
+        "author" => "著者",
+        "title_original" => "【書籍化！】サンプル【アニメ化！】",
+        "author_original" => "著者【受賞】"
+      }
+
+      described_class.normalize_entry!(entry, config: enabled_config)
+
+      expect(entry["title"]).to eq("サンプル")
+      expect(entry["author"]).to eq("著者")
+      expect(entry["promo_tags"]).to eq(["書籍化！", "アニメ化！", "受賞"])
+
+      described_class.normalize_entry!(entry, config: described_class.build_config(enabled: false))
+
+      expect(entry["title"]).to eq("【書籍化！】サンプル【アニメ化！】")
+      expect(entry["author"]).to eq("著者【受賞】")
+      expect(entry["promo_tags"]).to be_empty
+      expect(entry["promo_tags_title"]).to be_empty
+      expect(entry["promo_tags_author"]).to be_empty
     end
   end
 end


### PR DESCRIPTION
- 2c57912e - Web UI設定画面のヒント文面を整理し、未設定時のデフォルト挙動を説明するヘルパーとメッセージ辞書を追加
  - プロモタグ除去の既定値を無効化し、明示設定時のみ除去が働くよう変更
  -  Web API／テーブル描画からのプロモタグ正規化を外し、レスポンス生成時にタイトルを書き換えないよう変更
  - 更新コマンドで更新差分がなくてもタイトル／プロモタグが追随するよう改善
  - 最新取得タイトルを保持する項目を導入し、プロモタグ除去は常に生データから派生させる管理へ再構成
  - rspecの更新
- 6338fb4a - 個別メニューでの操作イベントを復旧
 1e36a442 - プロモタグ抽出を拡張しタイトルと著者のタグを整備