### PR TITLE
Fix/system updater redirect

### DIFF
--- a/lib/narou/system_updater.rb
+++ b/lib/narou/system_updater.rb
@@ -101,6 +101,14 @@ module Narou
       raise Error, "ダウンロードがリダイレクト回数上限を超えました" if limit <= 0
 
       perform_download_request(uri) do |response|
+        if response.is_a?(Net::HTTPRedirection)
+          location = response["location"]
+          raise Error, "リダイレクト先の URL が不正です" unless location && !location.empty?
+
+          new_uri = build_redirect_uri(uri, location)
+          return http_download(new_uri, destination, limit - 1)
+        end
+
         response.value
         File.open(destination, "wb") do |file|
           response.read_body do |chunk|
@@ -108,13 +116,18 @@ module Narou
           end
         end
       end
-    rescue Net::HTTPRedirection => e
-      new_uri = URI(e.response["location"])
-      http_download(new_uri, destination, limit - 1)
     rescue Net::HTTPRetriableError => e
       raise Error, "HTTP #{e.response.code} #{e.response.message}"
     rescue Net::HTTPExceptions => e
       raise Error, "HTTP #{e.response.code} #{e.response.message}"
+    end
+
+    def build_redirect_uri(current_uri, location)
+      new_uri = URI.parse(location)
+      new_uri = current_uri.merge(new_uri) if new_uri.relative?
+      new_uri
+    rescue URI::InvalidURIError
+      raise Error, "リダイレクト先の URL が不正です"
     end
 
     def perform_download_request(uri)

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -5,7 +5,7 @@
 #
 
 module Narou
-  VERSION = "2.0.0"
+  VERSION = "2.0.1"
 
   commit_path = File.expand_path("../commitversion", __dir__)
   commit_value = if File.exist?(commit_path)

--- a/spec/narou/system_updater_spec.rb
+++ b/spec/narou/system_updater_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "tempfile"
 require_relative "../../lib/narou/system_updater"
 
 RSpec.describe Narou::SystemUpdater do
@@ -87,6 +88,47 @@ RSpec.describe Narou::SystemUpdater do
       result = updater.update_from_github
 
       expect(result.asset_name).to eq("narou-mod-999.0.0-x64-mingw-ucrt.gem")
+    end
+  end
+
+  describe "#http_download" do
+    let(:source_uri) { URI("https://example.com/narou-mod.gem") }
+    let(:tempfile) do
+      file = Tempfile.new("narou-system-updater")
+      file.close
+      file
+    end
+    let(:destination) { tempfile.path }
+
+    after do
+      tempfile.unlink
+    rescue StandardError
+      # noop
+    end
+
+    it "follows HTTP redirects" do
+      redirect_uri = "https://cdn.example.com/narou-mod.gem"
+      redirect_response = Net::HTTPFound.new("1.1", "302", "Found")
+      redirect_response["location"] = redirect_uri
+
+      success_response = Net::HTTPOK.new("1.1", "200", "OK")
+      allow(success_response).to receive(:value).and_return(success_response)
+      allow(success_response).to receive(:read_body).and_yield("chunk")
+
+      expect(updater).to receive(:perform_download_request).with(source_uri).ordered.and_yield(redirect_response)
+      expect(updater).to receive(:perform_download_request).with(URI(redirect_uri)).ordered.and_yield(success_response)
+
+      updater.send(:http_download, source_uri, destination)
+
+      expect(File.binread(destination)).to eq("chunk")
+    end
+
+    it "raises error when redirect location is missing" do
+      redirect_response = Net::HTTPFound.new("1.1", "302", "Found")
+      expect(updater).to receive(:perform_download_request).with(source_uri).and_yield(redirect_response)
+
+      expect { updater.send(:http_download, source_uri, destination) }
+        .to raise_error(Narou::SystemUpdater::Error, /リダイレクト先の URL が不正/)
     end
   end
 end


### PR DESCRIPTION
[システムアップデータのリダイレクト処理を修正](https://github.com/ponponusa/narou-mod/commit/3c66a923769efbfb151333de695a1b23a7841598) 
- GitHub Release のダウンロードで 3xx 応答を追跡するよう http_download を更新
- Location ヘッダー検証とリダイレクト URL 解決ロジックを追加
- リダイレクトを扱うテストケースを system_updater_spec に追加