### PR TITLE
Fix/init requires database

### DIFF
--- a/lib/narou.rb
+++ b/lib/narou.rb
@@ -106,6 +106,7 @@ module Narou
       return nil if already_init?
       FileUtils.mkdir(LOCAL_SETTING_DIR_NAME)
       puts "#{LOCAL_SETTING_DIR_NAME}/ を作成しました"
+      require_relative "database"
       Database.init
     end
 

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -5,7 +5,7 @@
 #
 
 module Narou
-  VERSION = "2.0.1"
+  VERSION = "2.0.2"
 
   commit_path = File.expand_path("../commitversion", __dir__)
   commit_value = if File.exist?(commit_path)

--- a/spec/narou_spec.rb
+++ b/spec/narou_spec.rb
@@ -4,6 +4,7 @@
 # Copyright 2013 whiteleaf. All rights reserved.
 #
 
+require "tmpdir"
 require "narou"
 
 describe Narou do
@@ -14,6 +15,33 @@ describe Narou do
   describe ".last_commit_year" do
     it "should be commited year" do
       expect(Narou.last_commit_year).to eq Time.now.year
+    end
+  end
+
+  describe ".init" do
+    around do |example|
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) { example.run }
+      end
+    end
+
+    it "loads Database before initializing" do
+      original_database = Object.const_get(:Database)
+      database_feature = original_database.method(:init).source_location&.first
+      feature_removed = false
+      if database_feature
+        feature_removed = $LOADED_FEATURES.delete(database_feature)
+      end
+      Object.send(:remove_const, :Database)
+      begin
+        expect { Narou.init }.not_to raise_error
+        expect(Dir).to exist(Narou::LOCAL_SETTING_DIR_NAME)
+      ensure
+        Object.send(:remove_const, :Database) if defined?(Database)
+        Object.const_set(:Database, original_database)
+        $LOADED_FEATURES << database_feature if feature_removed && database_feature && !$LOADED_FEATURES.include?(database_feature)
+        Narou.flush_cache
+      end
     end
   end
 


### PR DESCRIPTION
[Narou.init の Database 初期化漏れを修正](https://github.com/ponponusa/narou-mod/commit/5e73d90a7a78e5e26fe9345c945f6df942130394) 

- init 実行時に database.rb を読み込んでから Database.init を呼び出すように変更
- Narou.init が Database 未定義でも動作することを確認するスペックを追加