### PR TITLE
2.0.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    narou-mod (2.0.0)
+    narou-mod (2.0.3)
       activesupport (~> 8.0, >= 8.1.0)
       bootsnap (~> 1.18, >= 1.18.6)
       csv (~> 3.3)

--- a/lib/command/init.rb
+++ b/lib/command/init.rb
@@ -309,5 +309,41 @@ module Command
         output(:summary, format("行の高さ: %.1f", line_height))
       end
     end
+
+    def print_help(argv)
+      topics = Array(argv).map(&:to_s).reject { |arg| arg.casecmp("help").zero? }
+      buffer = String.new
+      buffer << @opt.help
+      buffer << <<~DETAIL.termcolor
+
+<bold><green>詳細ヘルプ:</green></bold>
+  --non-interactive / 環境変数 NAROU_NONINTERACTIVE
+    対話なしで初期化を完了します。AozoraEpub3 の場所と行の高さを必ず指定してください。
+
+  --output-mode verbose|summary|silent
+    verbose : 進行ログをすべて表示します。
+    summary : 初期化結果だけを表示します。
+    silent  : 標準出力へ一切出力しません。
+
+  AozoraEpub3 の設定
+    既存の設定を使いたい場合は --path :keep を指定してください。
+    新しい場所を指定する場合は --path /path/to/AozoraEpub3 を使います。
+
+  行の高さの変更
+    --line-height で数値(em)を指定するとプリセットを上書きできます。
+
+  組み合わせ例
+    narou-mod init --non-interactive --output-mode summary \
+      --path /opt/narou/AozoraEpub3 --line-height 1.8
+
+DETAIL
+      unless topics.empty?
+        buffer << <<~TOPIC.termcolor
+
+<bold><yellow>未対応のヘルプトピック:</yellow></bold> #{topics.join(", ")}
+TOPIC
+      end
+      emit_help_output(buffer)
+    end
   end
 end

--- a/lib/command/init.rb
+++ b/lib/command/init.rb
@@ -10,6 +10,18 @@ require_relative "../tty_helper"
 
 module Command
   class Init < CommandBase
+    OUTPUT_MODES = %w[verbose summary silent].freeze
+    OUTPUT_MODE_PRIORITY = {
+      verbose: 0,
+      summary: 1,
+      silent: 2
+    }.freeze
+    MESSAGE_PRIORITY = {
+      verbose: 0,
+      summary: 1,
+      always: 2
+    }.freeze
+
     def self.oneline_help
       if Narou.already_init?
         "AozoraEpub3 の再設定を行います"
@@ -20,6 +32,8 @@ module Command
 
     def initialize
       super("[options]")
+      @options["output_mode"] = "verbose"
+      @summary_data = {}
       if Narou.already_init?
         opt_message(<<-MSG)
   ・AozoraEpub3 の再設定を行います。
@@ -41,6 +55,17 @@ module Command
           error e.message
           exit Narou::EXIT_ERROR_CODE
         end
+      end
+      @opt.on("--non-interactive", "対話なしで初期化を実行する (環境変数 NAROU_NONINTERACTIVE と同等)") do
+        @options["non_interactive"] = true
+      end
+      @opt.on("--output-mode MODE", "出力レベルを指定する (verbose|summary|silent)") do |mode|
+        normalized = mode.to_s.strip.downcase
+        unless OUTPUT_MODES.include?(normalized)
+          error "--output-mode は #{OUTPUT_MODES.join('/')} のいずれかを指定してください"
+          exit Narou::EXIT_ERROR_CODE
+        end
+        @options["output_mode"] = normalized
       end
     end
 
@@ -64,6 +89,7 @@ module Command
 
   # 入力を省略したい場合、-p と -l を両方指定してやる必要あり
   narou-mod init -p /path/to/aozora -l 1.8
+  narou-mod init --non-interactive --output-mode summary -p /path/to/aozora -l 1.8
 
   Options:
       MSG
@@ -71,59 +97,75 @@ module Command
 
     def execute(argv)
       super
+      @summary_data = {}
+      @output_mode = parse_output_mode(@options["output_mode"])
       if Narou.already_init?
         init_aozoraepub3(true)
+        output_summary_results
       else
-        Narou.init
-        puts "-" * 30
+        Narou.init(silent: silent_mode?)
+        output(:verbose, "-" * 30)
         init_aozoraepub3
-        puts "初期化が完了しました！"
-        puts "現在のフォルダ下で各種コマンドが使用出来るようになりました。"
-  puts "まずは narou-mod help で簡単な説明を御覧ください。"
+        output_summary_results
+        output(:summary, "初期化が完了しました！")
+        output(:verbose, "現在のフォルダ下で各種コマンドが使用出来るようになりました。")
+        output(:verbose, "まずは narou-mod help で簡単な説明を御覧ください。")
       end
     end
 
     def init_aozoraepub3(force = false)
       @global_setting = Inventory.load("global_setting", :global)
-      if !force && @global_setting["aozoraepub3dir"]
+      current_dir = @global_setting["aozoraepub3dir"]
+      current_line_height = @global_setting["line-height"]
+      if !force && current_dir && @options["aozora_dirname"].nil? && @options["line_height"].nil?
+        @summary_data[:used_existing] = true
+        @summary_data[:aozora_dir] = current_dir
+        @summary_data[:line_height] = current_line_height if current_line_height
         return
       end
-      puts "<bold><green>AozoraEpub3の設定を行います</green></bold>".termcolor
-      unless @global_setting["aozoraepub3dir"]
-        puts "<bold><red>#{"!!!WARNING!!!".center(70)}</red></bold>".termcolor
-  puts "AozoraEpub3の構成ファイルを書き換えます。narou-mod コマンド用に別途新規インストールしておくことをオススメします"
+      @summary_data[:used_existing] = false
+      output(:summary, "<bold><green>AozoraEpub3の設定を行います</green></bold>".termcolor)
+      unless current_dir
+        output(:summary, "<bold><red>#{"!!!WARNING!!!".center(70)}</red></bold>".termcolor)
+        output(:summary, "AozoraEpub3の構成ファイルを書き換えます。narou-mod コマンド用に別途新規インストールしておくことをオススメします")
       end
 
       path = nil
       if @options["aozora_dirname"]
         path = normalize_aozoraepub3_path(@options["aozora_dirname"])
-        print "\n<bold><green>指定されたフォルダにAozoraEpub3がありません。</green></bold>\n".termcolor unless path
+        unless path
+          output(:always, "<bold><green>指定されたフォルダにAozoraEpub3がありません。</green></bold>".termcolor)
+          output(:always, "")
+        end
       end
 
-      # 非対話（CI/rspec 等）では入力待ちしない：既存設定があれば採用、なければスキップ
       aozora_path =
         if path
           path
-        elsif TTYHelper.non_interactive?
+        elsif non_interactive?
           @global_setting["aozoraepub3dir"]
         else
           ask_aozoraepub3_path
         end
 
       unless aozora_path
-  puts "設定をスキップしました。あとで " + "<bold><yellow>narou-mod init</yellow></bold>".termcolor + " で再度設定出来ます"
+        @summary_data[:setup_skipped] = true
+        output(:summary, "設定をスキップしました。あとで <bold><yellow>narou-mod init</yellow></bold> で再度設定出来ます".termcolor)
         return
       end
 
       line_height =
-        @options["line_height"] || (TTYHelper.non_interactive? ? Narou.line_height(default: 1.8) : ask_line_height)
+        @options["line_height"] || (non_interactive? ? Narou.line_height(default: 1.8) : ask_line_height)
 
-      puts
+      output(:verbose, "")
       rewrite_aozoraepub3_files(aozora_path, line_height)
       @global_setting["aozoraepub3dir"] = aozora_path
       @global_setting["line-height"] = line_height
       @global_setting.save
-      puts "<bold><green>AozoraEpub3の設定を終了しました</green></bold>".termcolor
+      @summary_data[:setup_skipped] = false
+      @summary_data[:aozora_dir] = aozora_path
+      @summary_data[:line_height] = line_height
+      output(:summary, "<bold><green>AozoraEpub3の設定を終了しました</green></bold>".termcolor)
     end
 
     def rewrite_aozoraepub3_files(aozora_path, line_height)
@@ -139,24 +181,24 @@ module Command
         chuki_tag << "\n" + custom_chuki_tag
       end
       File.write(chuki_tag_path, chuki_tag)
-      puts "(次のファイルを書き換えました)"
-      puts chuki_tag_path
-      puts
+      output(:verbose, "(次のファイルを書き換えました)")
+      output(:verbose, chuki_tag_path)
+      output(:verbose, "")
       # ファイルコピー
       src = ["AozoraEpub3.ini", "vertical_font.css"]
       dst = ["AozoraEpub3.ini", "template/OPS/css_custom/vertical_font.css"]
-      puts "(次のファイルをコピーor上書きしました)"
+      output(:verbose, "(次のファイルをコピーor上書きしました)")
       src.size.times do |i|
         src_full_path = File.join(Narou.preset_dir, src[i])
         dst_full_path = File.join(aozora_path, dst[i])
         Helper.erb_copy(src_full_path, dst_full_path, binding)
-        puts dst_full_path
+        output(:verbose, dst_full_path)
       end
     end
 
     def ask_aozoraepub3_path
-      # 非対話環境では入力を読まない
-      return nil if TTYHelper.non_interactive?
+  # 非対話環境では入力を読まない
+  return nil if non_interactive?
       puts
       print "<bold><green>AozoraEpub3のあるフォルダを入力して下さい:</green></bold>\n(未入力でスキップ".termcolor
       if @global_setting["aozoraepub3dir"]
@@ -175,8 +217,8 @@ module Command
     end
 
     def ask_line_height
-      # 非対話環境ではデフォルトを返す（安全側）
-      return Narou.line_height(default: 1.8) if TTYHelper.non_interactive?
+  # 非対話環境ではデフォルトを返す（安全側）
+  return Narou.line_height(default: 1.8) if non_interactive?
       # 後方互換のために未設定時の line_height デフォルトは 1.6 だが、
       # オススメは 1.8 なので入力時のデフォルトは 1.8 にする
       line_height = Narou.line_height(default: 1.8)
@@ -218,6 +260,54 @@ module Command
         return path
       end
       nil
+    end
+
+    def parse_output_mode(value)
+      symbol = value.to_s.strip.downcase
+      symbol = "verbose" unless OUTPUT_MODES.include?(symbol)
+      symbol.to_sym
+    end
+
+    def non_interactive?
+      !!(@options["non_interactive"] || TTYHelper.non_interactive?)
+    end
+
+    def output_mode
+      @output_mode ||= :verbose
+    end
+
+    def silent_mode?
+      output_mode == :silent
+    end
+
+    def can_output?(level)
+      return true if level == :always
+      MESSAGE_PRIORITY[level] >= OUTPUT_MODE_PRIORITY[output_mode]
+    end
+
+    def output(level, message = nil)
+      return unless can_output?(level)
+      message = yield if block_given?
+      return if message.nil?
+      message.to_s.split(/\n/, -1).each do |line|
+        puts line
+      end
+    end
+
+    def output_summary_results
+      aozora_dir = @summary_data[:aozora_dir]
+      line_height = @summary_data[:line_height]
+      if @summary_data[:used_existing]
+        output(:summary, "AozoraEpub3 の設定は既存の値 (#{aozora_dir || "未設定"}) を利用しました。")
+      elsif @summary_data[:setup_skipped]
+        output(:summary, "AozoraEpub3 の設定をスキップしました。")
+      elsif aozora_dir
+        output(:summary, "AozoraEpub3 フォルダ: #{aozora_dir}")
+      end
+
+      if line_height
+        output(:summary, format("行の高さ: %.1f", line_height))
+      end
     end
   end
 end

--- a/lib/commandbase.rb
+++ b/lib/commandbase.rb
@@ -46,14 +46,20 @@ module Command
     end
 
     def display_help!
-      STDOUT.puts @opt.help
+      emit_help_output(@opt.help)
       exit
     end
 
     def execute(argv)
+      if help_token?(argv)
+        handle_help(argv)
+      end
       @options.clear
       load_local_settings
       @opt.parse!(argv)
+      if help_token?(argv)
+        handle_help(argv)
+      end
     rescue OptionParser::InvalidOption => e
       error "不明なオプションです(#{e})"
       exit Narou::EXIT_ERROR_CODE
@@ -185,6 +191,33 @@ module Command
     #
     def disable_logging
       self.stream_io = stream_io.dup_with_disabled_logging
+    end
+
+    protected
+
+    def emit_help_output(text)
+      return if text.nil? || text.empty?
+      streams = [STDOUT]
+      streams << $stdout unless $stdout.equal?(STDOUT)
+      streams.each do |io|
+        io.write(text)
+        io.flush if io.respond_to?(:flush)
+      end
+    end
+
+    private
+
+    def handle_help(argv)
+      if respond_to?(:print_help, true)
+        hook_call(:print_help, argv)
+        exit
+      else
+        display_help!
+      end
+    end
+
+    def help_token?(argv)
+      argv.any? { |arg| arg.to_s.casecmp("help").zero? }
     end
   end
 end

--- a/lib/commandbase.rb
+++ b/lib/commandbase.rb
@@ -51,9 +51,6 @@ module Command
     end
 
     def execute(argv)
-      if help_token?(argv)
-        handle_help(argv)
-      end
       @options.clear
       load_local_settings
       @opt.parse!(argv)
@@ -217,7 +214,8 @@ module Command
     end
 
     def help_token?(argv)
-      argv.any? { |arg| arg.to_s.casecmp("help").zero? }
+      first = argv.first
+      first && first.to_s.casecmp("help").zero?
     end
   end
 end

--- a/lib/database.rb
+++ b/lib/database.rb
@@ -32,10 +32,10 @@ class Database
   #
   # データベース初期設定
   #
-  def self.init
+  def self.init(silent: false)
     unless File.exist?(ARCHIVE_ROOT_DIR_PATH)
       FileUtils.mkdir(ARCHIVE_ROOT_DIR_PATH)
-      puts ARCHIVE_ROOT_DIR_PATH + " を作成しました"
+      puts ARCHIVE_ROOT_DIR_PATH + " を作成しました" unless silent
     end
   end
 

--- a/lib/narou.rb
+++ b/lib/narou.rb
@@ -102,12 +102,12 @@ module Narou
       root_dir.present?
     end
 
-    def init
+    def init(silent: false)
       return nil if already_init?
       FileUtils.mkdir(LOCAL_SETTING_DIR_NAME)
-      puts "#{LOCAL_SETTING_DIR_NAME}/ を作成しました"
+      puts "#{LOCAL_SETTING_DIR_NAME}/ を作成しました" unless silent
       require_relative "database"
-      Database.init
+      Database.init(silent: silent)
     end
 
     #

--- a/lib/tty_helper.rb
+++ b/lib/tty_helper.rb
@@ -5,13 +5,16 @@
 #
 
 module TTYHelper
-  def self.non_interactive?
-    ENV["NAROU_NONINTERACTIVE"] == "1"
+  def self.non_interactive?(input = $stdin)
+    return true if ENV["NAROU_NONINTERACTIVE"] == "1"
+    io = input || $stdin
+    return true unless io.respond_to?(:tty?) && io.tty?
+    false
   end
 
   # Y/N 確認（非対話時は default で即返す）
   def self.ask_yes_no(message, default: true, in_io: $stdin, out_io: $stdout)
-    return default if non_interactive?
+    return default if non_interactive?(in_io)
     out_io.print("#{message} [y/N]: ")
     ans = in_io.gets&.strip&.downcase
     return default if ans.nil? || ans.empty?
@@ -20,7 +23,7 @@ module TTYHelper
 
   # 「Enterで続行」待ち（非対話時はスキップ）
   def self.pause(message = "続行するには Enter を押してください…", in_io: $stdin, out_io: $stdout)
-    return if non_interactive?
+    return if non_interactive?(in_io)
     out_io.puts(message)
     in_io.gets
   end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -5,7 +5,7 @@
 #
 
 module Narou
-  VERSION = "2.0.2"
+  VERSION = "2.0.3"
 
   commit_path = File.expand_path("../commitversion", __dir__)
   commit_value = if File.exist?(commit_path)

--- a/spec/command/init_spec.rb
+++ b/spec/command/init_spec.rb
@@ -23,9 +23,9 @@ RSpec.describe Command::Init do
 
   let(:aozora_dir) { File.join(Dir.pwd, "AozoraEpub3") }
 
-  def prepare_aozora_dir
-    FileUtils.mkdir_p(aozora_dir)
-    File.write(File.join(aozora_dir, "AozoraEpub3.jar"), "")
+  def prepare_aozora_dir(path = aozora_dir)
+    FileUtils.mkdir_p(path)
+    File.write(File.join(path, "AozoraEpub3.jar"), "")
   end
 
   def build_command
@@ -76,6 +76,16 @@ RSpec.describe Command::Init do
         rescue SystemExit
         end
       end.to output(a_string_including("未対応のヘルプトピック").and(include("mystery"))).to_stdout
+    end
+
+    it "allows using the literal string help as an option value" do
+      help_dir = File.join(Dir.pwd, "help")
+      prepare_aozora_dir(help_dir)
+      command = build_command
+
+      expect do
+        command.execute(["--non-interactive", "--output-mode", "summary", "--path", help_dir, "--line-height", "1.9"])
+      end.to output(a_string_including("AozoraEpub3 フォルダ: #{help_dir}")).to_stdout
     end
   end
 end

--- a/spec/command/init_spec.rb
+++ b/spec/command/init_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+require "fileutils"
+
+RSpec.describe Command::Init do
+  around do |example|
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        begin
+          Narou.flush_cache if Narou.respond_to?(:flush_cache)
+          Inventory.clear if Inventory.respond_to?(:clear)
+          FileUtils.mkdir_p(Narou::GLOBAL_SETTING_DIR_NAME)
+          example.run
+        ensure
+          Narou.flush_cache if Narou.respond_to?(:flush_cache)
+          Inventory.clear if Inventory.respond_to?(:clear)
+        end
+      end
+    end
+  end
+
+  let(:aozora_dir) { File.join(Dir.pwd, "AozoraEpub3") }
+
+  def prepare_aozora_dir
+    FileUtils.mkdir_p(aozora_dir)
+    File.write(File.join(aozora_dir, "AozoraEpub3.jar"), "")
+  end
+
+  def build_command
+    Command::Init.new.tap do |command|
+      allow(command).to receive(:rewrite_aozoraepub3_files)
+    end
+  end
+
+  describe "non-interactive execution" do
+    it "suppresses stdout when output mode is silent" do
+      prepare_aozora_dir
+      command = build_command
+
+      expect do
+        command.execute(["--non-interactive", "--output-mode", "silent", "--path", aozora_dir, "--line-height", "1.9"])
+      end.to output("").to_stdout
+    end
+
+    it "prints summary of selected settings" do
+      prepare_aozora_dir
+      command = build_command
+
+      expect do
+        command.execute(["--non-interactive", "--output-mode", "summary", "--path", aozora_dir, "--line-height", "1.9"])
+      end.to output(a_string_including("AozoraEpub3 フォルダ: #{aozora_dir}")
+                      .and(include("行の高さ: 1.9"))).to_stdout
+    end
+  end
+end

--- a/spec/command/init_spec.rb
+++ b/spec/command/init_spec.rb
@@ -54,4 +54,28 @@ RSpec.describe Command::Init do
                       .and(include("行の高さ: 1.9"))).to_stdout
     end
   end
+
+  describe "help output" do
+    it "prints extended guidance when help is requested" do
+      command = Command::Init.new
+
+      expect do
+        begin
+          command.execute(["help"])
+        rescue SystemExit
+        end
+      end.to output(a_string_including("詳細ヘルプ").and(include("--non-interactive"))).to_stdout
+    end
+
+    it "reports unknown help topics" do
+      command = Command::Init.new
+
+      expect do
+        begin
+          command.execute(["help", "mystery"])
+        rescue SystemExit
+        end
+      end.to output(a_string_including("未対応のヘルプトピック").and(include("mystery"))).to_stdout
+    end
+  end
 end

--- a/spec/tty_helper_spec.rb
+++ b/spec/tty_helper_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "stringio"
+
+RSpec.describe TTYHelper do
+  describe ".non_interactive?" do
+    around do |example|
+      original = ENV["NAROU_NONINTERACTIVE"]
+      begin
+        ENV.delete("NAROU_NONINTERACTIVE")
+        example.run
+      ensure
+        if original
+          ENV["NAROU_NONINTERACTIVE"] = original
+        else
+          ENV.delete("NAROU_NONINTERACTIVE")
+        end
+      end
+    end
+
+    it "returns true when the environment forces non-interactive mode" do
+      ENV["NAROU_NONINTERACTIVE"] = "1"
+      expect(described_class.non_interactive?).to be(true)
+    end
+
+    it "returns true when the input does not support TTY operations" do
+      non_tty = StringIO.new
+      expect(described_class.non_interactive?(non_tty)).to be(true)
+    end
+
+    it "returns false when the input is a TTY" do
+      fake_tty = instance_double(IO, tty?: true)
+      expect(described_class.non_interactive?(fake_tty)).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
[init コマンドに非対話・出力モード指定を追加](https://github.com/ponponusa/narou-mod/commit/2aa616afe7fbe52cf780273a9a53c1f80738d118) 

- --non-interactive と --output-mode で自動初期化と出力抑制を選択可能にした
- init 実行時のメッセージ出力をモード別に制御し、要約情報を表示
- Narou.init / Database.init でサイレント実行時は作成メッセージを抑制
- 非対話オプションと出力モードを検証する init コマンドのRSpecを追加
- ヘルプ出力を複数ストリームへ転送
- init 詳細ヘルプとテストを追加
- docker などの環境では自動で非対話オプションを有効にする