### PR TITLE
fix: CI gemビルドのバージョン取得パス修正とgemspec説明改善

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
       - name: Get version
         id: get_version
         run: |
-          VERSION=$(ruby -r ./lib/version.rb -e 'print Narou::VERSION + (Narou::COMMIT ? "-#{Narou::COMMIT}" : "")')
+          VERSION=$(ruby -r ./lib/core/version.rb -e 'print Narou::VERSION + (Narou::COMMIT ? "-#{Narou::COMMIT}" : "")')
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
       - name: Build gem (Linux/macOS)

--- a/narou-mod.gemspec
+++ b/narou-mod.gemspec
@@ -183,12 +183,15 @@ Gem::Specification.new do |gem|
   # NOTE: プラットフォーム固有の gem (win32ole, bootsnap) は Gemfile の
   #       platforms 指定で管理しているため、開発時の bundle install は
   #       問題なく動作する。gemspec での指定は gem install 時のみ影響。
+  #
+  # Windows: x64-mingw-ucrt プラットフォーム固有gem
+  # Linux/macOS: Gem::Platform::RUBY (汎用gem、全アーキテクチャ対応)
   gem.platform = Gem.win_platform? ? Gem::Platform.new("x64-mingw-ucrt") : Gem::Platform::RUBY
 
   if Gem.win_platform?
     gem.add_runtime_dependency "win32ole", "~> 1.9"
   else
-    # Linux/macOS は汎用 gem（x86_64/arm64 両対応）
+    # Linux/macOS は汎用 gem（x86_64/arm64/aarch64 等、全アーキテクチャ対応）
     gem.add_runtime_dependency "bootsnap", "~> 1.18", ">= 1.18.6"
   end
 


### PR DESCRIPTION
- CI: lib/version.rb -> lib/core/version.rb にパス修正
- gemspec: プラットフォーム設定のコメントを明確化
  - Linux/macOS版は汎用gem(全アーキテクチャ対応)であることを明記