### PR TITLE
fix: Shell command injection脆弱性を修正

### DIFF
--- a/lib/utilities/helper.rb
+++ b/lib/utilities/helper.rb
@@ -8,6 +8,7 @@ require "erb"
 require "open3"
 require "time"
 require "systemu"
+require "shellwords"
 
 #
 # 雑多なお助けメソッド群
@@ -92,7 +93,8 @@ module Helper
   def open_browser_linux(address, error_message)
     %w(xdg-open firefox w3m).each do |browser|
       next unless command_available?(browser)
-      system(%!#{browser} "#{address}"!)
+      # 配列形式でsystemを呼び出すことでシェルインジェクションを防止
+      system(browser, address)
       return if $?.success?
     end
     warn error_message
@@ -104,11 +106,12 @@ module Helper
     end
     case determine_os
     when :windows
-      system(%!explorer "file:///#{path}"!.encode(Encoding::Windows_31J))
+      # 配列形式でコマンドインジェクションを防止
+      system("explorer", "file:///#{path}".encode(Encoding::Windows_31J))
     when :cygwin
-      system(%!cygstart "#{path}"!)
+      system("cygstart", path)
     when :mac
-      system(%!open "#{path}"!)
+      system("open", path)
     when :wsl
       open_directory_wsl(path, "フォルダが開けませんでした")
     else
@@ -154,14 +157,16 @@ module Helper
       return if $?.success?
     end
     begin
-      windows_path = `wslpath -w "#{path}"`.strip
+      # Open3.capture2を使用してシェルインジェクションを防止
+      windows_path, status = Open3.capture2("wslpath", "-w", path)
+      windows_path = windows_path.strip
       windows_path = path if windows_path.empty?
     rescue Errno::ENOENT
       windows_path = path
     end
-    escaped = windows_path.gsub("'", "''")
     begin
-      system("powershell.exe", "-NoProfile", "-Command", "Start-Process '#{escaped}'")
+      # PowerShellコマンドを配列形式で実行してインジェクションを防止
+      system("powershell.exe", "-NoProfile", "-Command", "Start-Process", "-FilePath", windows_path)
       return if $?.success?
     rescue Errno::ENOENT
       # powershell.exe が見つからない場合は警告にフォールバック


### PR DESCRIPTION
## 修正内容

### Shell command injection警告の修正（Error 5件）

lib/utilities/helper.rbで、ユーザー入力に依存する可能性のある値を
シェルコマンドに渡す際の脆弱性を修正しました。

#### 修正箇所

1. **open_browser_linux** (line 93-101)
   - Before: `system(%!#{browser} "#{address}"!)`
   - After: `system(browser, address)`
   - 配列形式でコマンドを実行し、シェル経由を回避

2. **open_directory** (line 103-120)
   - Before: `system(%!explorer "file:///#{path}"!)`
   - After: `system("explorer", "file:///#{path}")`
   - 全てのOS (Windows/Cygwin/Mac) で配列形式に変更

3. **open_directory_wsl** (line 154-175)
   - Before: バッククオート `` `wslpath -w "#{path}"` ``
   - After: `Open3.capture2("wslpath", "-w", path)`
   - PowerShellコマンドも配列形式に変更

#### 対策の原理

Rubyの`system()`メソッドは：
- 文字列形式: シェル経由で実行されるため、インジェクションのリスクあり
- 配列形式: シェルを経由せず直接実行されるため、安全

#### テスト結果
- 全テスト成功（1293 examples, 0 failures）
- 既存機能に影響なし