### PR TITLE
release: v3.0.1 バグ修正とタスクキュー画面の改善

### DIFF
--- a/frontend/src/components/TaskQueue.svelte
+++ b/frontend/src/components/TaskQueue.svelte
@@ -427,7 +427,7 @@
     <div class="flex flex-col lg:flex-row gap-4">
       <!-- サマリーカード -->
       {#if taskSummary}
-        <div class="grid grid-cols-2 lg:grid-cols-6 gap-3 lg:w-2/3">
+        <div class="grid grid-cols-2 lg:grid-cols-6 gap-2 lg:w-2/5">
           <button
             onclick={() => {
               draftStatusFilter = "running";
@@ -512,7 +512,7 @@
       {/if}
 
       <!-- フィルタ・ソートコントロール -->
-      <div class="bg-white dark:bg-gray-800 rounded-lg shadow-md p-4 lg:w-1/3">
+      <div class="bg-white dark:bg-gray-800 rounded-lg shadow-md p-4 lg:w-3/5">
         <div class="flex flex-col sm:flex-row gap-4 items-end">
           <!-- テキスト検索 -->
           <div class="flex-1">

--- a/frontend/src/components/TaskQueue.svelte
+++ b/frontend/src/components/TaskQueue.svelte
@@ -99,14 +99,28 @@
    * 既存のタスク配列とサマリーをマージ（差分更新）
    * - 新規タスク: 追加
    * - 既存タスク: 更新
-   * - サマリーに含まれない古いタスク: 保持（初回ロード時のデータ）
+   * - サマリーに含まれない古いタスク: 完了/失敗済みは保持、queued/runningは削除（キャンセル対応）
    */
   function mergeTasks(existing: Task[], summary: TaskSummary): Task[] {
-    // 既存タスクをMapに変換（id → Task）
-    const taskMap = new Map(existing.map((t) => [t.id, t]));
-
-    // サマリーから全タスクを抽出して更新
+    // サマリーから全タスクを抽出
     const incomingTasks = extractTasksFromSummary(summary);
+    const incomingIds = new Set(incomingTasks.map((t) => t.id));
+
+    // 既存タスクをフィルタリング
+    // - サマリーに含まれるタスク: 保持（後で更新）
+    // - サマリーに含まれないタスク:
+    //   - queued/running: 削除（キャンセルされた可能性）
+    //   - completed/failed/canceled: 保持（履歴として）
+    const filteredExisting = existing.filter((t) => {
+      if (incomingIds.has(t.id)) return true;
+      // サマリーに含まれないqueued/runningタスクは削除
+      return t.status !== "queued" && t.status !== "running";
+    });
+
+    // フィルタ済みタスクをMapに変換
+    const taskMap = new Map(filteredExisting.map((t) => [t.id, t]));
+
+    // サマリーのタスクで更新
     for (const task of incomingTasks) {
       taskMap.set(task.id, task);
     }

--- a/frontend/src/components/TaskQueue.svelte
+++ b/frontend/src/components/TaskQueue.svelte
@@ -61,6 +61,48 @@
   // PushServer接続
   let pushServerUnsubscribe: (() => void) | null = null;
 
+  /**
+   * サマリーデータから全タスクを抽出
+   */
+  function extractTasksFromSummary(summary: TaskSummary): Task[] {
+    const tasks: Task[] = [];
+    if (summary.current) tasks.push(summary.current);
+    if (summary.convert_current) tasks.push(summary.convert_current);
+    if (summary.queued) tasks.push(...summary.queued);
+    if (summary.convert_queued) tasks.push(...summary.convert_queued);
+    if (summary.recent_completed) tasks.push(...summary.recent_completed);
+    if (summary.recent_failed) tasks.push(...summary.recent_failed);
+    return tasks;
+  }
+
+  /**
+   * 既存のタスク配列とサマリーをマージ（差分更新）
+   * - 新規タスク: 追加
+   * - 既存タスク: 更新
+   * - サマリーに含まれない古いタスク: 保持（初回ロード時のデータ）
+   */
+  function mergeTasks(existing: Task[], summary: TaskSummary): Task[] {
+    // 既存タスクをMapに変換（id → Task）
+    const taskMap = new Map(existing.map((t) => [t.id, t]));
+
+    // サマリーから全タスクを抽出して更新
+    const incomingTasks = extractTasksFromSummary(summary);
+    for (const task of incomingTasks) {
+      taskMap.set(task.id, task);
+    }
+
+    // 配列に戻す
+    return Array.from(taskMap.values());
+  }
+
+  /**
+   * サマリーデータでタスクを差分更新
+   */
+  function updateTasksFromSummary(summary: TaskSummary) {
+    allTasks = mergeTasks(allTasks, summary);
+    taskSummary = summary;
+  }
+
   // === Svelte 5 Runes: リアクティブな派生データ ===
   // ステップ1: フィルタリング
   const filteredTasks = $derived.by(() => {
@@ -316,18 +358,21 @@
    * マウント時の処理
    */
   onMount(async () => {
-    // 初回データ取得
+    // 初回データ取得（全タスクをAPIから取得）
     await fetchTasks();
 
-    // 定期更新（5秒ごと）
-    updateTimer = setInterval(fetchTasks, 5000);
+    // 定期更新（30秒ごと、フォールバック用）
+    updateTimer = setInterval(fetchTasks, 30000);
 
-    // PushServer通知を購読
+    // PushServer通知を購読（差分更新）
     const pushServer = getPushServer();
     if (pushServer) {
-      const listener = (data: any) => {
-        // notification.task.updated イベントをリッスン
-        fetchTasks();
+      const listener = (data: TaskSummary) => {
+        // notification.task.updated イベントのデータを直接使用して差分更新
+        // APIリクエストなしでリアルタイム更新
+        if (data) {
+          updateTasksFromSummary(data);
+        }
       };
       pushServer.on("notification.task.updated", listener);
       pushServerUnsubscribe = () =>

--- a/frontend/src/components/TaskQueue.svelte
+++ b/frontend/src/components/TaskQueue.svelte
@@ -488,7 +488,7 @@
                 完了
               </div>
               <div class="text-xl font-bold text-green-700 dark:text-green-300">
-                {taskSummary.recent_completed.length}
+                {taskSummary.completed_count}
               </div>
             </div>
           </button>
@@ -504,7 +504,7 @@
                 失敗
               </div>
               <div class="text-xl font-bold text-red-700 dark:text-red-300">
-                {taskSummary.recent_failed.length}
+                {taskSummary.failed_count}
               </div>
             </div>
           </button>

--- a/frontend/src/components/TaskQueue.svelte
+++ b/frontend/src/components/TaskQueue.svelte
@@ -55,11 +55,31 @@
   let isLoading = $state(true);
   let error = $state<string | null>(null);
 
-  // 定期更新タイマー
-  let updateTimer: ReturnType<typeof setInterval> | null = null;
+  // 経過時間リアルタイム更新用
+  let now = $state(Date.now());
+  let elapsedTimer: ReturnType<typeof setInterval> | null = null;
 
   // PushServer接続
   let pushServerUnsubscribe: (() => void) | null = null;
+
+  /**
+   * 経過時間を計算（実行中タスクはリアルタイム更新）
+   */
+  function getElapsedTime(task: Task): number {
+    if (task.status === "running" && task.started_at) {
+      // 実行中: フロントで計算（リアルタイム更新）
+      return (now - new Date(task.started_at).getTime()) / 1000;
+    } else if (task.completed_at && task.started_at) {
+      // 完了/失敗: 開始と完了の差分（固定値）
+      return (
+        (new Date(task.completed_at).getTime() -
+          new Date(task.started_at).getTime()) /
+        1000
+      );
+    }
+    // それ以外: バックエンドの値を使用
+    return task.elapsed_time;
+  }
 
   /**
    * サマリーデータから全タスクを抽出
@@ -361,8 +381,10 @@
     // 初回データ取得（全タスクをAPIから取得）
     await fetchTasks();
 
-    // 定期更新（30秒ごと、フォールバック用）
-    updateTimer = setInterval(fetchTasks, 30000);
+    // 経過時間リアルタイム更新用タイマー（1秒ごと）
+    elapsedTimer = setInterval(() => {
+      now = Date.now();
+    }, 1000);
 
     // PushServer通知を購読（差分更新）
     const pushServer = getPushServer();
@@ -384,9 +406,9 @@
    * アンマウント時の処理
    */
   onDestroy(() => {
-    if (updateTimer) {
-      clearInterval(updateTimer);
-      updateTimer = null;
+    if (elapsedTimer) {
+      clearInterval(elapsedTimer);
+      elapsedTimer = null;
     }
 
     if (pushServerUnsubscribe) {
@@ -563,6 +585,14 @@
               title="フィルターをクリア"
             >
               ✕
+            </button>
+            <button
+              onclick={fetchTasks}
+              disabled={isLoading}
+              class="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              title="テーブルを更新"
+            >
+              <i class="fas fa-sync-alt" class:fa-spin={isLoading}></i>
             </button>
           </div>
         </div>
@@ -817,7 +847,7 @@
                   <td
                     class="px-3 py-2 whitespace-nowrap text-xs text-gray-900 dark:text-gray-100"
                   >
-                    {task.elapsed_time.toFixed(1)}秒
+                    {getElapsedTime(task).toFixed(1)}秒
                   </td>
                   <td class="px-3 py-2 whitespace-nowrap text-sm">
                     <div class="flex gap-1">

--- a/frontend/src/components/TaskQueue.svelte
+++ b/frontend/src/components/TaskQueue.svelte
@@ -433,24 +433,6 @@
           </button>
           <button
             onclick={() => {
-              draftStatusFilter = "paused";
-              handleSearch();
-            }}
-            class="bg-yellow-50 dark:bg-yellow-900/20 rounded-lg p-3 hover:bg-yellow-100 dark:hover:bg-yellow-900/30 transition-colors cursor-pointer text-left"
-          >
-            <div class="flex flex-col items-center justify-center h-full">
-              <div class="text-xs text-yellow-600 dark:text-yellow-400 mb-1">
-                一時停止
-              </div>
-              <div
-                class="text-xl font-bold text-yellow-700 dark:text-yellow-300"
-              >
-                {allTasks.filter((t) => t.status === "paused").length}
-              </div>
-            </div>
-          </button>
-          <button
-            onclick={() => {
               draftStatusFilter = "completed";
               handleSearch();
             }}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -57,6 +57,8 @@ export interface TaskSummary {
   queued: Task[];
   recent_completed: Task[];
   recent_failed: Task[];
+  completed_count: number;
+  failed_count: number;
   // 変換専用ワーカーの状態
   convert_current?: Task;
   convert_queued: Task[];

--- a/lib/core/version.rb
+++ b/lib/core/version.rb
@@ -5,9 +5,9 @@
 #
 
 module Narou
-  VERSION = "3.0.0".freeze
+  VERSION = "3.0.1".freeze
 
-  commit_path = "../commitversion"
+  commit_path = File.expand_path("../../commitversion", __dir__)
   commit_value = if File.exist?(commit_path)
                    content = File.read(commit_path).strip
                    content.empty? ? nil : content

--- a/lib/novel/downloader.rb
+++ b/lib/novel/downloader.rb
@@ -261,7 +261,7 @@ class Downloader
     when true
       unless tags.include?("end")
         update_database if update_subtitles.count == 0
-        require "lib/novel/command/tag" unless defined?(Command::Tag)
+        require "cli/command/tag" unless defined?(Command::Tag)
         Command::Tag.execute!(%W(#{id} --add end --color white --no-overwrite-color), io: Narou::NullIO.new)
         msg = old_toc.empty? ? "完結しているようです" : "完結したようです"
         @stream.puts "<cyan>#{id_and_title.escape} は#{msg}</cyan>".termcolor
@@ -270,7 +270,7 @@ class Downloader
     when false
       if tags.include?("end")
         update_database if update_subtitles.size == 0
-        require "lib/novel/command/tag" unless defined?(Command::Tag)
+        require "cli/command/tag" unless defined?(Command::Tag)
         Command::Tag.execute!(@id, "--delete", "end", io: Narou::NullIO.new)
         @stream.puts "<cyan>#{id_and_title.escape} は連載を再開したようです</cyan>".termcolor
         return_status = :ok
@@ -340,11 +340,11 @@ class Downloader
         when "2"
           return true
         when "3"
-          require "lib/novel/command/freeze" unless defined?(Command::Freeze)
+          require "cli/command/freeze" unless defined?(Command::Freeze)
           Command::Freeze.execute!(latest_toc["toc_url"])
           return true
         when "4"
-          require "lib/novel/command/backup" unless defined?(Command::Backup)
+          require "cli/command/backup" unless defined?(Command::Backup)
           Command::Backup.execute!(latest_toc["toc_url"])
         when "5"
           if Narou.web?
@@ -358,7 +358,7 @@ class Downloader
         when "7"
           Helper.open_directory(Downloader.get_novel_data_dir_by_target(latest_toc["toc_url"]))
         when "8"
-          require "lib/novel/command/convert" unless defined?(Command::Convert)
+          require "cli/command/convert" unless defined?(Command::Convert)
           Command::Convert.execute!(latest_toc["toc_url"], sync: true)
         end
         unless Narou.web?

--- a/lib/novel/downloader/toc_processor.rb
+++ b/lib/novel/downloader/toc_processor.rb
@@ -131,8 +131,8 @@ SocketError => e
         @stream.error "小説が削除されているか非公開な可能性があります"
         sleep_for_download
         if database.novel_exists?(@id)
-          require "lib/novel/downloader/command/tag" unless defined?(Command::Tag)
-          require "lib/novel/downloader/command/freeze" unless defined?(Command::Freeze)
+          require "cli/command/tag" unless defined?(Command::Tag)
+          require "cli/command/freeze" unless defined?(Command::Freeze)
           Command::Tag.execute!(%W(#{@id} --add 404 --color white --no-overwrite-color), io: Narou::NullIO.new)
           Command::Freeze.execute!(@id, "--on")
         end

--- a/lib/web/api/v2/tasks.rb
+++ b/lib/web/api/v2/tasks.rb
@@ -58,6 +58,8 @@ module Narou
                         .sort_by { |t| t[:failed_at] || t[:created_at] || "" }
                         .reverse
                         .first(10),
+                completed_count: (web_summary[:completed_count] || 0) + (convert_summary[:completed_count] || 0),
+                failed_count: (web_summary[:failed_count] || 0) + (convert_summary[:failed_count] || 0),
                 convert_current: convert_summary[:current],
                 convert_queued: convert_summary[:queued] || []
               }

--- a/lib/web/routes/static_file.rb
+++ b/lib/web/routes/static_file.rb
@@ -36,6 +36,8 @@ module StaticFileRoutes
         index_path = File.join(StaticFileRoutes.frontend_dist_dir, "index.html")
 
         if File.exist?(index_path)
+          # HTMLは常に最新を確認（ハッシュ付きアセットへの参照を更新するため）
+          headers "Cache-Control" => "no-cache, must-revalidate"
           send_file index_path
         else
           halt 500, "Frontend not built. Run 'cd frontend && npm run build' first."
@@ -64,6 +66,8 @@ module StaticFileRoutes
         asset_path = File.join(StaticFileRoutes.frontend_dist_dir, "_astro", asset_filename)
 
         if File.exist?(asset_path)
+          # ハッシュ付きアセットは長期キャッシュ可能（1年間）
+          headers "Cache-Control" => "public, max-age=31536000, immutable"
           send_file asset_path
         else
           halt 404
@@ -114,12 +118,13 @@ module StaticFileRoutes
       unless self.class.legacy_mode?
         json_path = File.join(StaticFileRoutes.frontend_dist_dir, "backend-port.json")
 
+        # 設定ファイルは常に最新を取得
+        headers "Cache-Control" => "no-store, must-revalidate"
+        content_type :json
         if File.exist?(json_path)
-          content_type :json
           send_file json_path
         else
           # ファイルがない場合はデフォルト値を返す
-          content_type :json
           { push_server_port: 5679 }.to_json
         end
       else
@@ -136,6 +141,8 @@ module StaticFileRoutes
           page_path = File.join(StaticFileRoutes.frontend_dist_dir, page, "index.html")
 
           if File.exist?(page_path)
+            # HTMLは常に最新を確認（ハッシュ付きアセットへの参照を更新するため）
+            headers "Cache-Control" => "no-cache, must-revalidate"
             send_file page_path
           else
             halt 404

--- a/lib/web/server/push_server.rb
+++ b/lib/web/server/push_server.rb
@@ -53,8 +53,12 @@ module Narou
             # 接続時に履歴を送信（タイムスタンプ付き）
             history_count = @history.compact.size
             $stderr.puts "[PushServer] Sending #{history_count} history messages to new connection" if $DEBUG
-            @history.compact.each do |message|
-              ws.send(JSON.generate(echo: message))
+            begin
+              @history.compact.each do |message|
+                ws.send(JSON.generate(echo: message))
+              end
+            rescue Errno::ECONNRESET, Errno::EPIPE, IOError
+              # 履歴送信中に接続が切れた場合は無視して続行
             end
 
             thread = Thread.new do

--- a/lib/web/workers/convert_worker.rb
+++ b/lib/web/workers/convert_worker.rb
@@ -205,6 +205,8 @@ module Narou
           .sort_by { |t| t[:failed_at] || t[:created_at] }
           .reverse
           .first(10),
+        completed_count: (web_summary[:completed_count] || 0) + (convert_summary[:completed_count] || 0),
+        failed_count: (web_summary[:failed_count] || 0) + (convert_summary[:failed_count] || 0),
         convert_current: convert_summary[:current],
         convert_queued: convert_summary[:queued]
       }
@@ -251,11 +253,15 @@ module Narou
 
     def get_tasks_summary_impl
       @mutex.synchronize do
+        completed_tasks = @task_history.select { |t| t.status == :completed }
+        failed_tasks = @task_history.select { |t| t.status == :failed }
         {
           current: @current_task&.to_h,
           queued: @tasks.values.select(&:queued?).map(&:to_h),
-          recent_completed: @task_history.select { |t| t.status == :completed }.first(10).map(&:to_h),
-          recent_failed: @task_history.select { |t| t.status == :failed }.first(10).map(&:to_h)
+          recent_completed: completed_tasks.first(10).map(&:to_h),
+          recent_failed: failed_tasks.first(10).map(&:to_h),
+          completed_count: completed_tasks.size,
+          failed_count: failed_tasks.size
         }
       end
     end

--- a/lib/web/workers/web_worker.rb
+++ b/lib/web/workers/web_worker.rb
@@ -246,11 +246,15 @@ module Narou
 
     def get_tasks_summary_impl
       @mutex.synchronize do
+        completed_tasks = @task_history.select { |t| t.status == :completed }
+        failed_tasks = @task_history.select { |t| t.status == :failed }
         {
           current: @current_task&.to_h,
           queued: @tasks.values.select(&:queued?).map(&:to_h),
-          recent_completed: @task_history.select { |t| t.status == :completed }.first(10).map(&:to_h),
-          recent_failed: @task_history.select { |t| t.status == :failed }.first(10).map(&:to_h)
+          recent_completed: completed_tasks.first(10).map(&:to_h),
+          recent_failed: failed_tasks.first(10).map(&:to_h),
+          completed_count: completed_tasks.size,
+          failed_count: failed_tasks.size
         }
       end
     end

--- a/spec/core/narou_spec.rb
+++ b/spec/core/narou_spec.rb
@@ -12,12 +12,6 @@ describe Narou do
     Narou.flush_cache
   end
 
-  describe ".last_commit_year" do
-    it "should be commited year" do
-      expect(Narou.last_commit_year).to eq Time.now.year
-    end
-  end
-
   describe ".init" do
     around do |example|
       Dir.mktmpdir do |dir|


### PR DESCRIPTION
### バグ修正
- commitversionファイルのパス解決を修正（バージョン表示にCOMMITが含まれない問題）
- コマンドファイルのrequireパスを修正
- タスクキュー画面の完了・失敗カウントが10以上で更新されない問題を修正
- PushServer履歴送信時のEPIPEエラーをハンドリング

### タスクキュー画面の改善
- 差分更新を実装（PushServer経由でリアルタイム更新）
- 経過時間をリアルタイム表示（1秒ごとにカウントアップ）
- 手動更新ボタンを追加（フォールバックを削除）
- 一時停止中サマリを削除（未実装のため）
- レイアウト調整（検索フォームの幅を拡大）

### フロントエンド配信の改善
- 静的ファイル配信にキャッシュ制御ヘッダーを追加
  - HTMLファイル: `no-cache, must-revalidate`
  - ハッシュ付きアセット: `max-age=31536000, immutable`
  - 設定JSON: `no-store`