### PR TITLE
fix: send / convert で発生する NameError を修正（require 漏れ）

### DIFF
--- a/lib/cli/command/convert.rb
+++ b/lib/cli/command/convert.rb
@@ -10,6 +10,7 @@ require "lib/novel/novelconverter"
 require "lib/core/inventory"
 require "lib/ebook/kindlestrip"
 require "lib/utilities/worker"
+require_relative "send"
 
 module Command
   class Convert < CommandBase

--- a/lib/cli/command/send.rb
+++ b/lib/cli/command/send.rb
@@ -5,6 +5,8 @@
 #
 
 require "lib/core/narou"
+require "lib/core/database"
+require "lib/novel/downloader"
 require "lib/utilities/helper"
 require "lib/ebook/device"
 


### PR DESCRIPTION
## 概要

以下2つの NameError を修正します。どちらも `require` 漏れが原因で、他の `lib/cli/command/*.rb` の慣習に揃える形で1〜2行追加するだけの変更です。

## 検証環境

- narou-mod 3.1.3 (15d38a0)
- Ruby 3.4.8 (arm64-darwin25, +PRISM)
- macOS 26.4.1 (Apple Silicon)

## 1. `narou-mod send <device> <ID>` が NameError で失敗する

### 再現

```
$ narou-mod send kindle 163
.../lib/cli/commandbase.rb:90:in 'Command::CommandBase#tagname_to_ids':
  uninitialized constant Command::CommandBase::Database (NameError)
  from .../lib/cli/command/send.rb:109:in 'Command::Send#execute'
```

### 原因

- `commandbase.rb#tagname_to_ids` (L90) が `Database.instance` を参照
- `send.rb#execute` (L90) も `Database.instance.each` を参照し、ファイルパス解決経由で `Downloader.get_data_by_target` (narou.rb:273) も参照
- しかし `send.rb` では `lib/core/database` も `lib/novel/downloader` も require されていない（`list.rb`, `freeze.rb`, `update.rb`, `backup.rb` 等は両方 require している）

### 修正

`lib/cli/command/send.rb` の冒頭に2行追加:

```ruby
require "lib/core/database"
require "lib/novel/downloader"
```

## 2. Web UI 等から convert 経由で送信すると NameError

### 再現

Web UI の「変換」操作等、`Command::Convert` 経由で自動送信が走る経路で:

```
[1/1] エラー: 163 - uninitialized constant Command::Convert::Send
```

### 原因

- `convert.rb#send_file_to_device` (L478) が `Send.execute!` を呼ぶ
- `lib/cli/command.rb` の `require_command` は実行されたサブコマンドのファイルだけを require する遅延ロード方式
- そのため convert からは `Command::Send` が未ロードで、Ruby は lexical scope 順に `Command::Convert::Send` → `Command::Send` → `::Send` を探し、すべて見つからず NameError
- エラーメッセージは最内 scope で報告されるため `Command::Convert::Send` という見た目になる

### 修正

`lib/cli/command/convert.rb` の冒頭に1行追加:

```ruby
require_relative "send"
```

## 動作確認

修正前後の挙動を `narou-mod send kindle <ID>` で確認:

- 修正前: 上記 NameError で終了
- 修正後: 正常に Kindle へファイル送信が完了

## 影響範囲

require の追加のみで、既存の挙動を変えるロジック変更はなし。