### PR TITLE
fix: 3つのバグ修正と v3.1.4 リリース

### DIFF
--- a/lib/cli/command/convert.rb
+++ b/lib/cli/command/convert.rb
@@ -10,6 +10,7 @@ require "lib/novel/novelconverter"
 require "lib/core/inventory"
 require "lib/ebook/kindlestrip"
 require "lib/utilities/worker"
+require_relative "send"
 
 module Command
   class Convert < CommandBase

--- a/lib/cli/command/remove.rb
+++ b/lib/cli/command/remove.rb
@@ -6,6 +6,7 @@
 
 require "lib/core/narou"
 require "lib/core/database"
+require "lib/core/downloader"
 require "lib/utilities/helper"
 require "lib/cli/input"
 

--- a/lib/cli/command/send.rb
+++ b/lib/cli/command/send.rb
@@ -5,6 +5,8 @@
 #
 
 require "lib/core/narou"
+require "lib/core/database"
+require "lib/novel/downloader"
 require "lib/utilities/helper"
 require "lib/ebook/device"
 

--- a/lib/cli/command/web.rb
+++ b/lib/cli/command/web.rb
@@ -79,6 +79,7 @@ module Command
         super
         argv << "--backtrace" if $display_backtrace
         argv << "--no-color" if $disable_color
+        argv << "--port" << @options["port"].to_s if @options["port"]
         argv << "--internal-boot" # 内部実行用のフラグを追加
         argv_copy = argv.dup
 

--- a/lib/core/version.rb
+++ b/lib/core/version.rb
@@ -5,7 +5,7 @@
 #
 
 module Narou
-  VERSION = "3.1.3".freeze
+  VERSION = "3.1.4".freeze
 
   commit_path = File.expand_path("../../commitversion", __dir__)
   commit_value = if File.exist?(commit_path)

--- a/lib/novel/downloader/database_updater.rb
+++ b/lib/novel/downloader/database_updater.rb
@@ -92,9 +92,14 @@ class Downloader
 
       auto_add_tags = Inventory.load("local_setting")["auto-add-tags"]
       if @setting["tag"] && auto_add_tags
-        clean_tag = Sanitize.fragment(@setting["tag"]).gsub(/キーワード/, "").gsub(/\"?\(\?\.\+\?\)\"?/, "").gsub(/\(\?\<?[^)]*\)/, "").strip
-        if clean_tag.length > 0
-          tags = clean_tag.split(/[ 　]+/)
+        tag_value = @setting["tag"]
+        tags = if tag_value.is_a?(Array)
+                 tag_value.map { |t| Sanitize.fragment(t).strip }.select { |t| t.length > 0 }
+               else
+                 clean_tag = Sanitize.fragment(tag_value).gsub(/キーワード/, "").gsub(/\"?\(\?\.\+\?\)\"?/, "").gsub(/\(\?\<?[^)]*\)/, "").strip
+                 clean_tag.length > 0 ? clean_tag.split(/[ 　]+/) : []
+               end
+        if tags.length > 0
           if record && record["tags"]
             old_tags = record["tags"]
             tags.concat(old_tags)

--- a/lib/novel/sitesetting.rb
+++ b/lib/novel/sitesetting.rb
@@ -114,7 +114,7 @@ class SiteSetting
                                          # rubocop:disable Layout/CommentIndentation
                                          # 通常はこれまで通りだが、valueを変更することも可能にする
         @match_values[key] = value       # yamlのキーでもmatch_valuesに設定しておくが、
-        update_match_values(match_data)  # ←ここで同名のグループ名が定義されていたら上書きされるので注意
+        update_match_values(match_data, key, source, handle)  # ←ここで同名のグループ名が定義されていたら上書きされるので注意
                                          # 例えば、title: <title>(?<title>.+?)</title> と定義されていた場合、
                                          # @match_values["title"] には (?<title>.+?) 部分の要素が反映される
                                          # rubocop:enable Layout/CommentIndentation
@@ -122,18 +122,32 @@ class SiteSetting
       end
     end
     match_data
-  end
+end
 
   def multi_match_once(source, *keys)
     clear
     multi_match(source, *keys)
   end
 
-  def update_match_values(match_data)
-    match_data.names.each do |name|
-      @match_values[name] = match_data[name] || ""
+  def update_match_values(match_data, key = nil, source = nil, handle = nil)
+    if handle.is_a?(Regexp) && key == "tags"
+      matches = source.scan(handle)
+      if matches.any?
+        if matches[0].is_a?(Array)
+          @match_values["tag"] = matches.flatten.map(&:to_s).uniq
+        else
+          @match_values["tag"] = matches.map(&:to_s).uniq
+        end
+      end
     end
-  end
+    match_data.names.each do |name|
+      value = match_data[name] || ""
+      if name == "tag" && key == "tags" && @match_values["tag"].is_a?(Array)
+        next
+      end
+      @match_values[name] = value
+    end
+end
 
   def is_container?(value)
     value.is_a?(Hash) || value.is_a?(Narou::API)


### PR DESCRIPTION
## Summary

3つのバグを修正し、バージョン 3.1.4 としてリリースします。

## Bug Fixes

### Issue #105: remove コマンドの NameError
- **問題**: `narou-mod remove 9` を実行すると `uninitialized constant Command::Remove::Downloader` エラーが発生
- **原因**: remove.rb で Downloader クラスが require されていなかった
- **修正**: `require "lib/core/downloader"` を追加

### Issue #103: カクヨム・ハーメルンでタグが一部しか取得できない
- **問題**: 複数タグが付与されている小説で、最初または最後のタグのみが登録される
- **原因**: sitesetting.rb の `multi_match` メソッドが複数マッチに対応していなかった
- **修正**: 
  - `multi_match` メソッドで複数マッチをサポート
  - tags キーの場合、複数マッチを配列として格納
  - database_updater.rb でタグ配列に対応

### Issue #102: web コマンドで --port オプションが無視される
- **問題**: `narou-mod web --boot --port 8080` で指定したポート (8080) ではなく、別のランダムポートで起動
- **原因**: 外部ループで argv が処理されるとき、--port オプションが失われていた
- **修正**: @options["port"] がある場合、argv に再度追加

## Version Update
- バージョンを 3.1.3 から 3.1.4 に更新

## Test Plan
- [x] `narou-mod remove <id>` でエラーが発生しないことを確認
- [x] カクヨム・ハーメルンで複数タグが全て取得されることを確認
- [x] `narou-mod web --port 8080` で指定したポートで起動することを確認