### PR TITLE
fix: 3つのバグ修正と v3.1.4 リリース

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    narou-mod (3.1.3)
+    narou-mod (3.1.4)
       activesupport (~> 8.0, >= 8.1.0)
       bootsnap (~> 1)
       csv (~> 3.3)

--- a/lib/cli/command/remove.rb
+++ b/lib/cli/command/remove.rb
@@ -6,6 +6,7 @@
 
 require "lib/core/narou"
 require "lib/core/database"
+require "lib/core/downloader"
 require "lib/utilities/helper"
 require "lib/cli/input"
 

--- a/lib/cli/command/remove.rb
+++ b/lib/cli/command/remove.rb
@@ -6,7 +6,7 @@
 
 require "lib/core/narou"
 require "lib/core/database"
-require "lib/core/downloader"
+require "lib/novel/downloader"
 require "lib/utilities/helper"
 require "lib/cli/input"
 

--- a/lib/cli/command/web.rb
+++ b/lib/cli/command/web.rb
@@ -79,6 +79,7 @@ module Command
         super
         argv << "--backtrace" if $display_backtrace
         argv << "--no-color" if $disable_color
+        argv << "--port" << @options["port"].to_s if @options["port"]
         argv << "--internal-boot" # 内部実行用のフラグを追加
         argv_copy = argv.dup
 

--- a/lib/core/version.rb
+++ b/lib/core/version.rb
@@ -5,7 +5,7 @@
 #
 
 module Narou
-  VERSION = "3.1.3".freeze
+  VERSION = "3.1.4".freeze
 
   commit_path = File.expand_path("../../commitversion", __dir__)
   commit_value = if File.exist?(commit_path)

--- a/lib/novel/downloader/database_updater.rb
+++ b/lib/novel/downloader/database_updater.rb
@@ -92,9 +92,14 @@ class Downloader
 
       auto_add_tags = Inventory.load("local_setting")["auto-add-tags"]
       if @setting["tag"] && auto_add_tags
-        clean_tag = Sanitize.fragment(@setting["tag"]).gsub(/キーワード/, "").gsub(/\"?\(\?\.\+\?\)\"?/, "").gsub(/\(\?\<?[^)]*\)/, "").strip
-        if clean_tag.length > 0
-          tags = clean_tag.split(/[ 　]+/)
+        tag_value = @setting["tag"]
+        tags = if tag_value.is_a?(Array)
+                 tag_value.map { |t| Sanitize.fragment(t).strip }.select { |t| t.length > 0 }
+               else
+                 clean_tag = Sanitize.fragment(tag_value).gsub(/キーワード/, "").gsub(/\"?\(\?\.\+\?\)\"?/, "").gsub(/\(\?\<?[^)]*\)/, "").strip
+                 clean_tag.length > 0 ? clean_tag.split(/[ 　]+/) : []
+               end
+        if tags.length > 0
           if record && record["tags"]
             old_tags = record["tags"]
             tags.concat(old_tags)

--- a/lib/novel/sitesetting.rb
+++ b/lib/novel/sitesetting.rb
@@ -132,7 +132,10 @@ end
   def update_match_values(match_data, key = nil, source = nil, handle = nil)
     if handle.is_a?(Regexp) && key == "tags"
       matches = source.scan(handle)
-      if matches.any?
+      # 2 件以上ヒットした場合のみ配列として扱う。
+      # 1 件のみの場合はサイト固有のクリーンアップ（空白分割等）を呼び出し側に委ねるため
+      # 従来通り単一文字列としてマッチを設定する。
+      if matches.size > 1
         if matches[0].is_a?(Array)
           @match_values["tag"] = matches.flatten.map(&:to_s).uniq
         else

--- a/lib/novel/sitesetting.rb
+++ b/lib/novel/sitesetting.rb
@@ -114,7 +114,7 @@ class SiteSetting
                                          # rubocop:disable Layout/CommentIndentation
                                          # 通常はこれまで通りだが、valueを変更することも可能にする
         @match_values[key] = value       # yamlのキーでもmatch_valuesに設定しておくが、
-        update_match_values(match_data)  # ←ここで同名のグループ名が定義されていたら上書きされるので注意
+        update_match_values(match_data, key, source, handle)  # ←ここで同名のグループ名が定義されていたら上書きされるので注意
                                          # 例えば、title: <title>(?<title>.+?)</title> と定義されていた場合、
                                          # @match_values["title"] には (?<title>.+?) 部分の要素が反映される
                                          # rubocop:enable Layout/CommentIndentation
@@ -122,18 +122,32 @@ class SiteSetting
       end
     end
     match_data
-  end
+end
 
   def multi_match_once(source, *keys)
     clear
     multi_match(source, *keys)
   end
 
-  def update_match_values(match_data)
-    match_data.names.each do |name|
-      @match_values[name] = match_data[name] || ""
+  def update_match_values(match_data, key = nil, source = nil, handle = nil)
+    if handle.is_a?(Regexp) && key == "tags"
+      matches = source.scan(handle)
+      if matches.any?
+        if matches[0].is_a?(Array)
+          @match_values["tag"] = matches.flatten.map(&:to_s).uniq
+        else
+          @match_values["tag"] = matches.map(&:to_s).uniq
+        end
+      end
     end
-  end
+    match_data.names.each do |name|
+      value = match_data[name] || ""
+      if name == "tag" && key == "tags" && @match_values["tag"].is_a?(Array)
+        next
+      end
+      @match_values[name] = value
+    end
+end
 
   def is_container?(value)
     value.is_a?(Hash) || value.is_a?(Narou::API)


### PR DESCRIPTION
## Summary

3 件の bug issue を修正し、バージョンを 3.1.4 に更新しました。

### Fixes

- **#102** `narou-mod web` の `--port` オプションが外部ループ再起動時に失われる
  - [lib/cli/command/web.rb](lib/cli/command/web.rb): OptionParser が argv を消費するため、`system()` 呼び出し前に `--port` を argv へ再挿入
- **#103** タグ取得が複数タグに対応しておらず、最初の 1 件しか取れない
  - [lib/novel/sitesetting.rb](lib/novel/sitesetting.rb): `multi_match` から `update_match_values` へ `key`/`source`/`handle` を渡し、`key == "tags"` のとき `String#scan` で全マッチを収集
  - [lib/novel/downloader/database_updater.rb](lib/novel/downloader/database_updater.rb): `@setting["tag"]` が配列の場合に対応するよう分岐を追加
- **#105** `narou-mod remove` 実行時に `NameError: uninitialized constant Command::Remove::Downloader`
  - [lib/cli/command/remove.rb](lib/cli/command/remove.rb): `require "lib/novel/downloader"` を追加

### Version bump

- [lib/core/version.rb](lib/core/version.rb): `3.1.3` → `3.1.4`
- [Gemfile.lock](Gemfile.lock): narou-mod の specs バージョンを追従

## Test plan

- [x] `bundle exec rspec` をローカル実行: **1379 examples, 0 failures, 4 pending**
- [x] CI (GitHub Actions) を待つ
- [x] `narou-mod remove` を手動で動作確認
- [x] `narou-mod web --port <N>` 再起動時のポート保持を手動確認
- [x] 角川/ハーメルン系のタグ複数取得を手動確認