### PR TITLE
chore(deps): yaml の transitive 脆弱性を overrides で解消

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7830,18 +7830,6 @@
       "integrity": "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg==",
       "license": "MIT"
     },
-    "node_modules/yaml-language-server/node_modules/yaml": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
-      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,5 +33,8 @@
     "prettier": "^3.8.1",
     "prettier-plugin-astro": "^0.14.1",
     "prettier-plugin-svelte": "^3.5.0"
+  },
+  "overrides": {
+    "yaml": "^2.8.3"
   }
 }


### PR DESCRIPTION
## Summary

- `frontend/package.json` に `overrides` を追加し、`yaml-language-server` 経由で混入していた `yaml@2.7.1` を `^2.8.3` (ロック上は `2.9.0`) に固定。
- 対象 advisory: [GHSA-48c2-rrv3-qjmp](https://github.com/advisories/GHSA-48c2-rrv3-qjmp) "yaml is vulnerable to Stack Overflow via deeply nested YAML collections" (moderate)
- ローカル `npm audit` の検出数: **7 → 2 件**

## 残った 2 件（本 PR ではスコープ外）

いずれも Astro v6 系への major bump が前提のため別 PR で検討:

- [GHSA-j687-52p2-xcff](https://github.com/advisories/GHSA-j687-52p2-xcff) Astro: XSS in `define:vars` via incomplete `</script>` tag sanitization (moderate)
- [GHSA-xr5h-phrj-8vxv](https://github.com/advisories/GHSA-xr5h-phrj-8vxv) Astro: Server island encrypted parameters vulnerable to cross-component replay (low)

## Dependabot の見え方について

GitHub UI 上は現時点で 33 alerts と表示されますが、ほとんどは `chore/frontend-deps-update` (PR #111) のマージ前に発行された stale alert で、最新の `frontend/package-lock.json` 上では既に解消済みです。Dependabot の次回再スキャン後に自動クローズされる想定。

## Test plan

- [x] `npm run check`（astro check / TypeScript 型検査）— エラーなし、警告のみ
- [x] `npm run build`（プロダクションビルド）— 成功 (5 page(s) built)
- [x] `npm audit` の検出数 7 → 2 件を確認
- [x] レビュアー側で必要に応じて `npm ci && npm run check && npm run build` でローカル再現