### PR TITLE
Advance vendored agent-context-maintainer pin to v0.1.1

### DIFF
--- a/.agents/skills/agent-context-maintainer/UPSTREAM.md
+++ b/.agents/skills/agent-context-maintainer/UPSTREAM.md
@@ -1,8 +1,8 @@
 # Upstream provenance
 
 - Repository: https://github.com/ponponusa/agent-context-maintainer
-- Imported commit: `596e859faa09c27e465371c3da73dc6407947ece` (tag `v0.1.0`)
-- Imported on: 2026-08-05
+- Imported commit: `25354c94db194f9c09bfaa3108542e9674325c7b` (tag `v0.1.1`)
+- Imported on: 2026-08-06
 - License: MIT; see `LICENSE` in this directory.
 
 ## Imported payload
@@ -30,13 +30,13 @@ English upstream documentation is authoritative; Japanese companion files follow
 
 ## Local integration patch
 
-`scripts/agent_context.py` carries three small local fixes:
+All three previous local integration patches have been upstreamed in `v0.1.1` and removed:
 
-- Preserve the line boundary when a replaced managed block is followed by hand-written content, and preserve a final newline for a block at EOF. The pinned upstream implementation consumes the end-marker newline, which can concatenate the marker with the following heading or leave generated-only files without a newline.
-- Treat an unchanged generated skill-route block as a no-op instead of rewriting `.agents/routing.md` on every `skills routes` run.
-- Omit the checkout-directory basename (`Root:` line) from the generated `core.md` snapshot and `skill-health.md` summary. The basename is not repository-stable, so embedding it makes the CI drift check fail for checkouts cloned under a different directory name.
+- Line boundary preservation following replaced managed blocks and final newline preservation at EOF (`replace_generated_block`).
+- Unchanged skill-route block no-op handling (`sync_skill_routes`).
+- Removal of non-repository-stable checkout-directory basename (`Root:` line) from `core.md` and `skill-health.md`.
 
-Keep these patches until upstream contains equivalent fixes, then remove them during a reviewed pin update. Re-verified against `v0.1.0` on 2026-08-05: upstream still lacks both fixes, so both patches were re-applied unchanged.
+Re-verified against `v0.1.1` on 2026-08-06: payload matches upstream `v0.1.1` cleanly with zero local patches.
 
 ## Known validation warnings
 
@@ -46,4 +46,4 @@ The pinned upstream payload is valid but currently reports these non-blocking Sk
 - `script-without-compatibility`: upstream frontmatter does not declare its Python compatibility field.
 - `codex-metadata-unparsed`: SkillOps records the Codex adapter but does not parse its schema.
 
-Keep these as upstream facts rather than patching the vendored `SKILL.md` locally. Re-evaluate them when updating the pinned commit. Re-confirmed unchanged with `v0.1.0` on 2026-08-05; the new `v0.1.0` listing-budget checks (`long-listing-entry`, `listing-budget-estimate`) report nothing for this repository.
+Keep these as upstream facts rather than patching the vendored `SKILL.md` locally. Re-evaluate them when updating the pinned commit. Re-confirmed unchanged with `v0.1.1` on 2026-08-06; the `v0.1.0` listing-budget checks (`long-listing-entry`, `listing-budget-estimate`) report nothing for this repository.

--- a/.agents/skills/agent-context-maintainer/scripts/agent_context.py
+++ b/.agents/skills/agent-context-maintainer/scripts/agent_context.py
@@ -1885,10 +1885,7 @@ def replace_generated_block(
         raise AgentContextError("current content has no valid generated block")
     replacement = generated_block_from_content(generated_content, markers).rstrip()
     suffix = current[span.end_end :]
-    if not suffix:
-        replacement += "\n"
-    elif not suffix.startswith(("\n", "\r")):
-        replacement += "\n"
+    replacement += "\n"
     return current[: span.begin_start] + replacement + suffix
 
 


### PR DESCRIPTION
## Summary

Advances the vendored `agent-context-maintainer` installation from `v0.1.0` to [`v0.1.1`](https://github.com/ponponusa/agent-context-maintainer/releases/tag/v0.1.1) (commit `25354c9`) and drops all three local patches recorded in `UPSTREAM.md` — each is now part of upstream:

1. **Line-boundary preservation in `replace_generated_block`** — upstream v0.1.1 additionally fixes a case our local patch still had: an intentional blank separator line between the generated block's end marker and following hand-written content was deleted on every replacement (found by Codex review on agent-context-maintainer#5).
2. **`skills routes` no-op when the generated block is unchanged.**
3. **Checkout-basename omission from generated output** (`Root:` line), which our CI drift check depends on.

`UPSTREAM.md` is updated in the same change: pinned commit, import date, and the local-patch section now records that the patches were upstreamed in v0.1.1 and removed.

## Validation

- Vendored `scripts/agent_context.py` is byte-identical to upstream `v0.1.1` (SHA-256 verified); every other imported payload path is unchanged between v0.1.0 and v0.1.1 and matches the tag.
- On a clean `git archive` extraction of this branch: `agent_context.py check .` passes, `scaffold . --agent codex --dry-run` reports no changes (generated files on `develop` are already at the fixed point), and a second scaffold/sync run is idempotent.
- `skills check` passes with only the three known upstream warnings already recorded in `UPSTREAM.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)